### PR TITLE
Update main.c - Clear Bottom Screen

### DIFF
--- a/rxtools/source/main.c
+++ b/rxtools/source/main.c
@@ -14,6 +14,7 @@
 
 void Initialize()
 {
+	ClearScreen(BOT_SCREEN, BLACK);
 	DrawString(TOP_SCREEN,  " INITIALIZE... ", 0, 240-8, WHITE, BLACK);
 	if(InitFS()){
 		DrawString(TOP_SCREEN,  " LOADING...    ", 0, 240-8, WHITE, BLACK);

--- a/rxtools/source/main.c
+++ b/rxtools/source/main.c
@@ -30,6 +30,7 @@ void Initialize()
     rxMode_boot();
 	
 	rxTools_boot:
+	ClearScreen(BOT_SCREEN, BLACK);
 	memset(TOP_SCREEN, 0x00, 0x46500);
 	memset(TOP_SCREEN2, 0x00, 0x46500);
 	ConsoleSetXY(15, 15);
@@ -47,6 +48,7 @@ void Initialize()
 
 int main(){
 	Initialize();
+	ClearScreen(BOT_SCREEN, BLACK);
 	DrawString(TOP_SCREEN, "SUPPORT THE ORIGINAL, NOT THE IMITATION!", 75, 240-10, GREY, BLACK);
 	//7.X Keys stuff
 	File KeyFile;


### PR DESCRIPTION
Clear bottom screen to black on boot. It's an eye sore. Especially with the new GUI. Tested this and it works! White screen was probably a side effect of spider payload. This change to main.c will clear bottom screen during initial boot of rxTools and set it to black.

If you ever decide to put a logo there, you can remove this. Otherwise this should do well in the mean time!