### PR TITLE
Rxmode: format, indent, rx_memmem

### DIFF
--- a/rxmode/native_firm/source/arm9/source/myThread/FS.h
+++ b/rxmode/native_firm/source/arm9/source/myThread/FS.h
@@ -1,9 +1,9 @@
 #ifndef FS_H
 #define FS_H
 #include <stdio.h>
-extern unsigned int fopen9(void *handle, wchar_t* name, unsigned int flag);
-extern void fwrite9(void* handle, unsigned int* bytesWritten, void* dst, unsigned int size);
-extern void fread9(void* handle, unsigned int* bytesRead, void *src, unsigned int size);
+extern unsigned int fopen9(void *handle, wchar_t *name, unsigned int flag);
+extern void fwrite9(void *handle, unsigned int *bytesWritten, void *dst, unsigned int size);
+extern void fread9(void *handle, unsigned int *bytesRead, void *src, unsigned int size);
 extern void fclose9(void *handle);
 
 #endif

--- a/rxmode/native_firm/source/arm9/source/myThread/lib.c
+++ b/rxmode/native_firm/source/arm9/source/myThread/lib.c
@@ -4,8 +4,8 @@
 // ---------------------------------------- //
 #include "lib.h"
 
-void *memset(void * ptr, int value, unsigned int num){
-    unsigned char *p = ptr;
+void *rx_memset(void * ptr, u8 value, u32 num){
+    u8 *p = ptr;
     while (num) {
         *p++ = value;
         num--;
@@ -13,20 +13,21 @@ void *memset(void * ptr, int value, unsigned int num){
     return ptr;
 }
 
-int rx_strcmp(char* s1, char* s2, unsigned int size, unsigned int w1, unsigned int w2){
+int rx_strcmp(char* s1, char* s2, u32 size, u32 w1, u32 w2){
+	
 	for(int i = 0; i < size; i++){
 		if(s1[i*w1] != s2[i*w2]) return 0;
 	}
 	return 1;
 }
 
-void rx_strcpy(char* dest, char* source, unsigned int size, unsigned int w1, unsigned int w2){
+void rx_strcpy(char* dest, char* source, u32 size, u32 w1, u32 w2){
 	for(int i = 0; i < size; i++){
 		dest[i*w1] = source[i*w2];
 	}
 }
 
-void rx_hextostr(unsigned int num, char* str) {
+void rx_hextostr(u32 num, void* str) {
 	int i;
     char *ptr = str + 8;
     for(i = 0; i < 8; i++){
@@ -38,10 +39,10 @@ void rx_hextostr(unsigned int num, char* str) {
     }
 }
 
-int memcmp(void* buf1, void* buf2, int size){
+int rx_memcmp(void* buf1, void* buf2, int size){
 	int equal = 0;
 	for(int i = 0; i < size; i++){
-		if(*((unsigned char*)buf1 + i) != *((unsigned char*)buf2 + i)){
+		if(*((u8*)buf1 + i) != *((u8*)buf2 + i)){
 			equal = i;
 			break;
 		}
@@ -49,6 +50,6 @@ int memcmp(void* buf1, void* buf2, int size){
 	return equal;
 }
 
-unsigned int getHID(){
-	return ~*(unsigned int*)0x10146000;
+u32 getHID(){
+	return ~*(u32*)0x10146000;
 }

--- a/rxmode/native_firm/source/arm9/source/myThread/lib.c
+++ b/rxmode/native_firm/source/arm9/source/myThread/lib.c
@@ -49,6 +49,34 @@ int rx_memcmp(void *buf1, void *buf2, int size) {
 	return equal;
 }
 
+/** Search the memory for target buffer.
+  * @param tb The buffer of your target.
+  * @param sb The memory where to look in.
+  * @param tl Length of tb.
+  * @param sl Length of sb.
+  * @retval   Where it is found in buffer.
+  */
+void* rx_memmem(const void* tb, const void* sb, u32 tl, u32 sl) {
+	char *ss = (char*)sb; //Backed up points from comparison, for source.
+	char *tp = (char*)tb, *sp = (char*)sb; //Current pointer in both buffers.
+	u32 lm = 0, lt = sl; //the length of matched part. And the total length
+	//T==S?	Y:T,S:Forward.L++.L==l?
+	//			Y:Sucuess, return.
+	//		N:T,S:Unwind.S:Forward.L=0.
+	while (lt --) {
+		if (*tp == *sp) {
+			tp++; sp++; lm++;
+			if (lm == tl) return ss;
+		} else {
+			lt += lm;
+			ss++;
+			tp = (char*)tb; sp = ss;
+			lm = 0;
+		}
+	}
+	return 0;
+}
+
 u32 getHID() {
 	return ~*(u32 *)0x10146000;
 }

--- a/rxmode/native_firm/source/arm9/source/myThread/lib.c
+++ b/rxmode/native_firm/source/arm9/source/myThread/lib.c
@@ -4,45 +4,44 @@
 // ---------------------------------------- //
 #include "lib.h"
 
-void *rx_memset(void * ptr, u8 value, u32 num){
-    u8 *p = ptr;
-    while (num) {
-        *p++ = value;
-        num--;
-    }
-    return ptr;
+void *rx_memset(void *ptr, u8 value, u32 num) {
+	u8 *p = ptr;
+	while (num) {
+		*p++ = value;
+		num--;
+	}
+	return ptr;
 }
 
-int rx_strcmp(char* s1, char* s2, u32 size, u32 w1, u32 w2){
-	
-	for(int i = 0; i < size; i++){
-		if(s1[i*w1] != s2[i*w2]) return 0;
+int rx_strcmp(char *s1, char *s2, u32 size, u32 w1, u32 w2) {
+	for (int i = 0; i < size; i++) {
+		if (s1[i * w1] != s2[i * w2]) { return 0; }
 	}
 	return 1;
 }
 
-void rx_strcpy(char* dest, char* source, u32 size, u32 w1, u32 w2){
-	for(int i = 0; i < size; i++){
-		dest[i*w1] = source[i*w2];
+void rx_strcpy(char *dest, char *source, u32 size, u32 w1, u32 w2) {
+	for (int i = 0; i < size; i++) {
+		dest[i * w1] = source[i * w2];
 	}
 }
 
-void rx_hextostr(u32 num, void* str) {
+void rx_hextostr(u32 num, void *str) {
 	int i;
-    char *ptr = str + 8;
-    for(i = 0; i < 8; i++){
+	char *ptr = str + 8;
+	for (i = 0; i < 8; i++) {
 		int x = (num & 0xF);
 		char y = '0';
-		if(x > 0x9) y +=7;
-        *--ptr = y + x;
-        num >>= 4;
-    }
+		if (x > 0x9) { y += 7; }
+		*--ptr = y + x;
+		num >>= 4;
+	}
 }
 
-int rx_memcmp(void* buf1, void* buf2, int size){
+int rx_memcmp(void *buf1, void *buf2, int size) {
 	int equal = 0;
-	for(int i = 0; i < size; i++){
-		if(*((u8*)buf1 + i) != *((u8*)buf2 + i)){
+	for (int i = 0; i < size; i++) {
+		if (*((u8 *)buf1 + i) != *((u8 *)buf2 + i)) {
 			equal = i;
 			break;
 		}
@@ -50,6 +49,6 @@ int rx_memcmp(void* buf1, void* buf2, int size){
 	return equal;
 }
 
-u32 getHID(){
-	return ~*(u32*)0x10146000;
+u32 getHID() {
+	return ~*(u32 *)0x10146000;
 }

--- a/rxmode/native_firm/source/arm9/source/myThread/lib.h
+++ b/rxmode/native_firm/source/arm9/source/myThread/lib.h
@@ -32,6 +32,8 @@ int rx_strcmp(char *s1, char *s2, u32 size, u32 w1, u32 w2);    // w1 = size of 
 void rx_strcpy(char *dest, char *source, u32 size, u32 w1, u32 w2);
 void rx_hextostr(u32 num, void *str);
 int rx_memcmp(void *buf1, void *buf2, int size);
+void* rx_memmem(const void* tb, const void* sb, u32 tl, u32 sl);
+
 static inline void svc_Backdoor(void *addr) {
 	register void *_r0 __asm("r0") = addr;
 	__asm volatile("SVC 0x7B" : : "r"(_r0));

--- a/rxmode/native_firm/source/arm9/source/myThread/lib.h
+++ b/rxmode/native_firm/source/arm9/source/myThread/lib.h
@@ -27,15 +27,14 @@ typedef volatile s64 vs64;
 #define VRAM (unsigned char*)0x18000000
 
 //The basic functions we will need
-void* rx_memset(void * ptr, u8 value, u32 num);
+void *rx_memset(void *ptr, u8 value, u32 num);
 int rx_strcmp(char *s1, char *s2, u32 size, u32 w1, u32 w2);    // w1 = size of string1 letters
-void rx_strcpy(char * dest, char * source, u32 size, u32 w1, u32 w2);
-void rx_hextostr(u32 num, void * str);
-int rx_memcmp(void* buf1, void* buf2, int size);
-static inline void svc_Backdoor(void *addr)
-{
-    register void *_r0 __asm ("r0") = addr;
-    __asm volatile ( "SVC 0x7B" : : "r"(_r0) );
+void rx_strcpy(char *dest, char *source, u32 size, u32 w1, u32 w2);
+void rx_hextostr(u32 num, void *str);
+int rx_memcmp(void *buf1, void *buf2, int size);
+static inline void svc_Backdoor(void *addr) {
+	register void *_r0 __asm("r0") = addr;
+	__asm volatile("SVC 0x7B" : : "r"(_r0));
 }
 
 //hid

--- a/rxmode/native_firm/source/arm9/source/myThread/lib.h
+++ b/rxmode/native_firm/source/arm9/source/myThread/lib.h
@@ -2,15 +2,36 @@
 // |      Copyright(c) 2015, Roxas75      | //
 // |         All rights reserved.         | //
 // ---------------------------------------- //
+
+typedef signed char s8;
+typedef signed short int s16;
+typedef signed int s32;
+typedef signed long s64;
+
+typedef unsigned char u8;
+typedef unsigned short int u16;
+typedef unsigned int u32;
+typedef unsigned long u64;
+
+typedef volatile u8 vu8;
+typedef volatile u16 vu16;
+typedef volatile u32 vu32;
+typedef volatile u64 vu64;
+
+typedef volatile s8 vs8;
+typedef volatile s16 vs16;
+typedef volatile s32 vs32;
+typedef volatile s64 vs64;
+
 #define FCRAM (unsigned char*)0x20000000
 #define VRAM (unsigned char*)0x18000000
 
 //The basic functions we will need
-void* memset(void * ptr, int value, unsigned int num);
-int rx_strcmp(char* s1, char*s2, unsigned int size, unsigned int w1, unsigned int w2);    // w1 = size of string1 letters
-void rx_strcpy(char* dest, char* source, unsigned int size, unsigned int w1, unsigned int w2);
-void rx_hextostr(unsigned int num, char* str);
-int memcmp(void* buf1, void* buf2, int size);
+void* rx_memset(void * ptr, u8 value, u32 num);
+int rx_strcmp(char *s1, char *s2, u32 size, u32 w1, u32 w2);    // w1 = size of string1 letters
+void rx_strcpy(char * dest, char * source, u32 size, u32 w1, u32 w2);
+void rx_hextostr(u32 num, void * str);
+int rx_memcmp(void* buf1, void* buf2, int size);
 static inline void svc_Backdoor(void *addr)
 {
     register void *_r0 __asm ("r0") = addr;
@@ -31,4 +52,4 @@ static inline void svc_Backdoor(void *addr)
 #define BUTTON_X      (1 << 10)
 #define BUTTON_Y      (1 << 11)
 
-unsigned int getHID();
+u32 getHID();

--- a/rxmode/native_firm/source/arm9/source/myThread/myThread.c
+++ b/rxmode/native_firm/source/arm9/source/myThread/myThread.c
@@ -9,55 +9,56 @@
 
 u8 handle[32];
 
-void memdump(wchar_t* filename, u8* buf, u32 size){
+void memdump(wchar_t *filename, u8 *buf, u32 size) {
 	u32 br;
-	for(int i = 0; i < 0x600000; i++){
+	for (int i = 0; i < 0x600000; i++) {
 		*(VRAM + i) = 0x77;			//Grey flush : Start Dumping
 	}
 	rx_memset(&handle, 0, 32);
 	fopen9(&handle, filename, 6);
 	fwrite9(&handle, &br, buf, size);
 	fclose9(&handle);
-	for(int i = 0; i < 0x600000; i++){
+	for (int i = 0; i < 0x600000; i++) {
 		*(VRAM + i) = 0xFF;			//White flush : Finished Dumping
 	}
 }
 static u8 originalcode[] = { 0x00, 0x00, 0x55, 0xE3, 0x01, 0x10, 0xA0, 0xE3, 0x11, 0x00, 0xA0, 0xE1, 0x03, 0x00, 0x00, 0x0A };
 static u8 patchcode[] = { 0x01, 0x00, 0xA0, 0xE3, 0x70, 0x80, 0xBD, 0xE8 };
-static u8* dest = (u8*)0x20000400;
-void patchregion(){
-	for(int i = 0; i < 8; i++) *(dest + i) = patchcode[i];
-}	
+static u8 *dest = (u8 *)0x20000400;
+void patchregion() {
+	for (int i = 0; i < 8; i++) { *(dest + i) = patchcode[i]; }
+}
 
-void patch_processes(){
-	char* mset = (char*)0x24000000;
-	u8* menu = (u8*)0x26A00000;
-	for(int i = 0; i < 0x600000; i+=4){
+void patch_processes() {
+	char *mset = (char *)0x24000000;
+	u8 *menu = (u8 *)0x26A00000;
+	for (int i = 0; i < 0x600000; i += 4) {
 		//System Menu code, which locks the region
-		if(dest == (u8*)0x20000400){	//This means we haven't still found our code
-			if( (*((u32*)(menu + i + 0x0)) == *((u32*)&originalcode[0x0])) &&
-				(*((u32*)(menu + i + 0x4)) == *((u32*)&originalcode[0x4])) &&
-				(*((u32*)(menu + i + 0x8)) == *((u32*)&originalcode[0x8])) &&
-				(*((u32*)(menu + i + 0xC)) == *((u32*)&originalcode[0xC]))){	
+		if (dest == (u8 *)0x20000400) {	//This means we haven't still found our code
+			if ((*((u32 *)(menu + i + 0x0)) == *((u32 *)&originalcode[0x0])) &&
+			    (*((u32 *)(menu + i + 0x4)) == *((u32 *)&originalcode[0x4])) &&
+			    (*((u32 *)(menu + i + 0x8)) == *((u32 *)&originalcode[0x8])) &&
+			    (*((u32 *)(menu + i + 0xC)) == *((u32 *)&originalcode[0xC]))) {
 				dest = menu + i;    //Basically, once we found where the code is, there is no point on searching it again
 				break;
 			}
 		}
 		//System Settings label
-		if(rx_strcmp(mset - i, "Ver.", 4, 2, 1)){
+		if (rx_strcmp(mset - i, "Ver.", 4, 2, 1)) {
 			rx_strcpy(mset - i, "Shit", 4, 2, 1);
 		}
 	}
 }
 
-void myThread(){
-	while(1){
+void myThread() {
+	while (1) {
 		/*if(getHID() & BUTTON_SELECT){
 			memdump(L"sdmc:/FCRAM.bin", 0x20000000, 0x10000);
 		}*/
 		patch_processes();
-		if(*((u32*)dest) != *((u32*)&patchcode[0]))
-			svc_Backdoor(&patchregion);		//Edit just if the code is not patched, or the arm9 will get mad
+		if (*((u32 *)dest) != *((u32 *)&patchcode[0])) {
+			svc_Backdoor(&patchregion);    //Edit just if the code is not patched, or the arm9 will get mad
+		}
 	}
 	__asm("SVC 0x09");
 }

--- a/rxmode/native_firm/source/arm9/source/myThread/myThread.c
+++ b/rxmode/native_firm/source/arm9/source/myThread/myThread.c
@@ -7,14 +7,14 @@
 #include <wchar.h>
 #include <stdio.h>
 
-unsigned char handle[32];
+u8 handle[32];
 
-void memdump(wchar_t* filename, unsigned char* buf, unsigned int size){
-	unsigned int br;
+void memdump(wchar_t* filename, u8* buf, u32 size){
+	u32 br;
 	for(int i = 0; i < 0x600000; i++){
 		*(VRAM + i) = 0x77;			//Grey flush : Start Dumping
 	}
-	memset(&handle, 0, 32);
+	rx_memset(&handle, 0, 32);
 	fopen9(&handle, filename, 6);
 	fwrite9(&handle, &br, buf, size);
 	fclose9(&handle);
@@ -22,23 +22,23 @@ void memdump(wchar_t* filename, unsigned char* buf, unsigned int size){
 		*(VRAM + i) = 0xFF;			//White flush : Finished Dumping
 	}
 }
-static unsigned char originalcode[] = { 0x00, 0x00, 0x55, 0xE3, 0x01, 0x10, 0xA0, 0xE3, 0x11, 0x00, 0xA0, 0xE1, 0x03, 0x00, 0x00, 0x0A };
-static unsigned char patchcode[] = { 0x01, 0x00, 0xA0, 0xE3, 0x70, 0x80, 0xBD, 0xE8 };
-static unsigned char* dest = 0x20000400;
+static u8 originalcode[] = { 0x00, 0x00, 0x55, 0xE3, 0x01, 0x10, 0xA0, 0xE3, 0x11, 0x00, 0xA0, 0xE1, 0x03, 0x00, 0x00, 0x0A };
+static u8 patchcode[] = { 0x01, 0x00, 0xA0, 0xE3, 0x70, 0x80, 0xBD, 0xE8 };
+static u8* dest = (u8*)0x20000400;
 void patchregion(){
 	for(int i = 0; i < 8; i++) *(dest + i) = patchcode[i];
 }	
 
 void patch_processes(){
-	unsigned char* mset = 0x24000000;
-	unsigned char* menu = 0x26A00000;
+	char* mset = (char*)0x24000000;
+	u8* menu = (u8*)0x26A00000;
 	for(int i = 0; i < 0x600000; i+=4){
 		//System Menu code, which locks the region
-		if(dest == 0x20000400){	//This means we haven't still found our code
-			if( (*((unsigned int*)(menu + i + 0x0)) == *((unsigned int*)&originalcode[0x0])) &&
-				(*((unsigned int*)(menu + i + 0x4)) == *((unsigned int*)&originalcode[0x4])) &&
-				(*((unsigned int*)(menu + i + 0x8)) == *((unsigned int*)&originalcode[0x8])) &&
-				(*((unsigned int*)(menu + i + 0xC)) == *((unsigned int*)&originalcode[0xC]))){	
+		if(dest == (u8*)0x20000400){	//This means we haven't still found our code
+			if( (*((u32*)(menu + i + 0x0)) == *((u32*)&originalcode[0x0])) &&
+				(*((u32*)(menu + i + 0x4)) == *((u32*)&originalcode[0x4])) &&
+				(*((u32*)(menu + i + 0x8)) == *((u32*)&originalcode[0x8])) &&
+				(*((u32*)(menu + i + 0xC)) == *((u32*)&originalcode[0xC]))){	
 				dest = menu + i;    //Basically, once we found where the code is, there is no point on searching it again
 				break;
 			}
@@ -56,7 +56,7 @@ void myThread(){
 			memdump(L"sdmc:/FCRAM.bin", 0x20000000, 0x10000);
 		}*/
 		patch_processes();
-		if(*((unsigned int*)dest) != *((unsigned int*)&patchcode[0]))
+		if(*((u32*)dest) != *((u32*)&patchcode[0]))
 			svc_Backdoor(&patchregion);		//Edit just if the code is not patched, or the arm9 will get mad
 	}
 	__asm("SVC 0x09");

--- a/rxmode/native_firm/source/arm9/source/myThread/myThread.c
+++ b/rxmode/native_firm/source/arm9/source/myThread/myThread.c
@@ -9,55 +9,52 @@
 
 u8 handle[32];
 
-void memdump(wchar_t *filename, u8 *buf, u32 size) {
-	u32 br;
-	for (int i = 0; i < 0x600000; i++) {
-		*(VRAM + i) = 0x77;			//Grey flush : Start Dumping
-	}
+void rx_memdump(wchar_t *filename, u8 *buf, u32 size) {
+	u32 br = 0;
+	//Flush grey: Dumping start.
+	rx_memset(VRAM, 0x77, 0x600000);
 	rx_memset(&handle, 0, 32);
 	fopen9(&handle, filename, 6);
 	fwrite9(&handle, &br, buf, size);
 	fclose9(&handle);
-	for (int i = 0; i < 0x600000; i++) {
-		*(VRAM + i) = 0xFF;			//White flush : Finished Dumping
-	}
+	rx_memset(VRAM, 0xFF, 0x600000);
 }
-static u8 originalcode[] = { 0x00, 0x00, 0x55, 0xE3, 0x01, 0x10, 0xA0, 0xE3, 0x11, 0x00, 0xA0, 0xE1, 0x03, 0x00, 0x00, 0x0A };
-static u8 patchcode[] = { 0x01, 0x00, 0xA0, 0xE3, 0x70, 0x80, 0xBD, 0xE8 };
-static u8 *dest = (u8 *)0x20000400;
-void patchregion() {
-	for (int i = 0; i < 8; i++) { *(dest + i) = patchcode[i]; }
+char originalcode[] = { 0x00, 0x00, 0x55, 0xE3, 0x01, 0x10, 0xA0, 0xE3, 0x11, 0x00, 0xA0, 0xE1, 0x03, 0x00, 0x00, 0x0A };
+char patchcode[] = { 0x01, 0x00, 0xA0, 0xE3, 0x70, 0x80, 0xBD, 0xE8 };
+char *dest = (char *)0x20000400;
+/** Patch System Menu code for region free. Indeed just memcpy. */
+void RegionLockFree(void) {
+	char *destp = dest, *patchp = patchcode;
+	u32 i = sizeof(patchcode);
+	while (i--) *(destp++) = *(patchp++);
 }
-
-void patch_processes() {
+/** Look up the System Menu code for region lock code.
+  * @retval If find the target code, return 1. otherwise, 0.
+  */
+u8 RegionLockSearch(void) {
 	char *mset = (char *)0x24000000;
-	u8 *menu = (u8 *)0x26A00000;
-	for (int i = 0; i < 0x600000; i += 4) {
-		//System Menu code, which locks the region
-		if (dest == (u8 *)0x20000400) {	//This means we haven't still found our code
-			if ((*((u32 *)(menu + i + 0x0)) == *((u32 *)&originalcode[0x0])) &&
-			    (*((u32 *)(menu + i + 0x4)) == *((u32 *)&originalcode[0x4])) &&
-			    (*((u32 *)(menu + i + 0x8)) == *((u32 *)&originalcode[0x8])) &&
-			    (*((u32 *)(menu + i + 0xC)) == *((u32 *)&originalcode[0xC]))) {
-				dest = menu + i;    //Basically, once we found where the code is, there is no point on searching it again
-				break;
-			}
-		}
+	char *menu = (char *)0x26A00000;
+	//System Menu code, which locks the region
+	dest = rx_memmem(originalcode, menu, sizeof(originalcode)/sizeof(u8), 0x600000);
+	char *msetlabel =  menu - dest + mset;
+	if (dest) {
 		//System Settings label
-		if (rx_strcmp(mset - i, "Ver.", 4, 2, 1)) {
-			rx_strcpy(mset - i, "Shit", 4, 2, 1);
+		if (rx_strcmp(msetlabel, "Ver.", 4, 2, 1)) {
+			rx_strcpy(msetlabel, "Shit", 4, 2, 1);
 		}
-	}
+		return 1;
+	} else return 0;
 }
 
 void myThread() {
 	while (1) {
 		/*if(getHID() & BUTTON_SELECT){
-			memdump(L"sdmc:/FCRAM.bin", 0x20000000, 0x10000);
+			rx_memdump(L"sdmc:/FCRAM.bin", 0x20000000, 0x10000);
 		}*/
-		patch_processes();
-		if (*((u32 *)dest) != *((u32 *)&patchcode[0])) {
-			svc_Backdoor(&patchregion);    //Edit just if the code is not patched, or the arm9 will get mad
+		if (RegionLockSearch()) {
+			if (*((u32 *)dest) != *((u32 *)&patchcode[0])) {
+				svc_Backdoor(&RegionLockFree);    //Edit just if the code is not patched, or the arm9 will get mad
+			}
 		}
 	}
 	__asm("SVC 0x09");


### PR DESCRIPTION
This brings these edits: *Now went for food..*
* Formatted, indented (tabs), used u8 (those short terms).
* `rx_memmem` for search a pattern (binary is ok) within a given buffer.
* ~~Renamed `MyThread` to `rxModeThread`.~~

About the `rx_memmem`, if you want to see that's actually working, tell me and i would show you the test program on my Windows 8.1 x64. I'm sure it should be faster than the original method.