### PR TITLE
rxTools: Decryption for 'encTitleKeys.bin' supported

### DIFF
--- a/rxtools/source/MainMenu.h
+++ b/rxtools/source/MainMenu.h
@@ -27,14 +27,15 @@ static void ShutDown(){
 
 static Menu DecryptMenu = {
 	"Decryption Options",
-	.Option = (MenuEntry[5]){
+	.Option = (MenuEntry[6]){
 		" Decrypt CTR Titles", &CTRDecryptor,
 		" Decrypt Title Keys", &DecryptTitleKeys,
+		" Decrypt encTitleKeys.bin", &DecryptTitleKeyFile,
 		" Generate Xorpads", &PadGen,
 		" Decrypt partitions", &DumpNandPartitions,
 		" Generate fat16 Xorpad", &GenerateNandXorpads,
 	},
-	5,
+	6,
 	0,
 	0
 };

--- a/rxtools/source/MainMenu.h
+++ b/rxtools/source/MainMenu.h
@@ -27,7 +27,7 @@ static void ShutDown(){
 
 static Menu DecryptMenu = {
 	"Decryption Options",
-	{
+	.Option = (MenuEntry[5]){
 		" Decrypt CTR Titles", &CTRDecryptor,
 		" Decrypt Title Keys", &DecryptTitleKeys,
 		" Generate Xorpads", &PadGen,
@@ -41,7 +41,7 @@ static Menu DecryptMenu = {
 
 static Menu DumpMenu = {
 	"Dumping Options",
-	{
+	.Option = (MenuEntry[3]){
 		" Create NAND dump", &NandDumper,
 		" Dump System Titles", &DumpNANDSystemTitles,
 		" Dump NAND Files", &dumpCoolFiles,
@@ -53,7 +53,7 @@ static Menu DumpMenu = {
 
 static Menu InjectMenu = {
 	"Injection Options",
-	{
+	.Option = (MenuEntry[2]){
 		" Inject EmuNAND partitions", &RebuildNand,
 		" Inject NAND Files", &restoreCoolFiles,
 	},
@@ -64,7 +64,7 @@ static Menu InjectMenu = {
 
 static Menu ExploitMenu = {
 	"Other Options",
-	{
+	.Option = (MenuEntry[3]){
 		" Downgrade MSET on SysNAND", &downgradeMSET,
 		" Install FBI over Health&Safety App", &installFBI,
 		" Restore original Health&Safety App", &restoreHS,
@@ -145,7 +145,7 @@ static void Credits(){
 
 static Menu MainMenu = {
 		"rxTools - Roxas75 [v2.6]",
-		{
+		.Option = (MenuEntry[7]){
 			" Launch rxMode in EmuNAND", &rxModeEmu,
 			" Launch rxMode in SysNAND", &rxModeSys,
 			" Decryption Options", &DecryptMenuInit,

--- a/rxtools/source/features/NandDumper.c
+++ b/rxtools/source/features/NandDumper.c
@@ -12,7 +12,7 @@
 
 #define NAND_SIZE 0x3AF00000
 #define NAND_SECTOR_SIZE 0x200
-#define BUF1 0x21000000
+#define BUF1 (void*)0x21000000
 
 char myString[256];		//for showing percentages
 

--- a/rxtools/source/features/TitleKeyDecrypt.c
+++ b/rxtools/source/features/TitleKeyDecrypt.c
@@ -13,130 +13,127 @@
 
 // From https://github.com/profi200/Project_CTR/blob/master/makerom/pki/prod.h#L19
 static const u8 common_keyy[6][16] = {
-    {0xD0, 0x7B, 0x33, 0x7F, 0x9C, 0xA4, 0x38, 0x59, 0x32, 0xA2, 0xE2, 0x57, 0x23, 0x23, 0x2E, 0xB9} , // 0 - eShop Titles
-    {0x0C, 0x76, 0x72, 0x30, 0xF0, 0x99, 0x8F, 0x1C, 0x46, 0x82, 0x82, 0x02, 0xFA, 0xAC, 0xBE, 0x4C} , // 1 - System Titles
-    {0xC4, 0x75, 0xCB, 0x3A, 0xB8, 0xC7, 0x88, 0xBB, 0x57, 0x5E, 0x12, 0xA1, 0x09, 0x07, 0xB8, 0xA4} , // 2
-    {0xE4, 0x86, 0xEE, 0xE3, 0xD0, 0xC0, 0x9C, 0x90, 0x2F, 0x66, 0x86, 0xD4, 0xC0, 0x6F, 0x64, 0x9F} , // 3
-    {0xED, 0x31, 0xBA, 0x9C, 0x04, 0xB0, 0x67, 0x50, 0x6C, 0x44, 0x97, 0xA3, 0x5B, 0x78, 0x04, 0xFC} , // 4
-    {0x5E, 0x66, 0x99, 0x8A, 0xB4, 0xE8, 0x93, 0x16, 0x06, 0x85, 0x0F, 0xD7, 0xA1, 0x6D, 0xD7, 0x55} , // 5
+	{0xD0, 0x7B, 0x33, 0x7F, 0x9C, 0xA4, 0x38, 0x59, 0x32, 0xA2, 0xE2, 0x57, 0x23, 0x23, 0x2E, 0xB9} , // 0 - eShop Titles
+	{0x0C, 0x76, 0x72, 0x30, 0xF0, 0x99, 0x8F, 0x1C, 0x46, 0x82, 0x82, 0x02, 0xFA, 0xAC, 0xBE, 0x4C} , // 1 - System Titles
+	{0xC4, 0x75, 0xCB, 0x3A, 0xB8, 0xC7, 0x88, 0xBB, 0x57, 0x5E, 0x12, 0xA1, 0x09, 0x07, 0xB8, 0xA4} , // 2
+	{0xE4, 0x86, 0xEE, 0xE3, 0xD0, 0xC0, 0x9C, 0x90, 0x2F, 0x66, 0x86, 0xD4, 0xC0, 0x6F, 0x64, 0x9F} , // 3
+	{0xED, 0x31, 0xBA, 0x9C, 0x04, 0xB0, 0x67, 0x50, 0x6C, 0x44, 0x97, 0xA3, 0x5B, 0x78, 0x04, 0xFC} , // 4
+	{0x5E, 0x66, 0x99, 0x8A, 0xB4, 0xE8, 0x93, 0x16, 0x06, 0x85, 0x0F, 0xD7, 0xA1, 0x6D, 0xD7, 0x55} , // 5
 };
 
 int nTicket = 0;
 int nKey = 0;
 int nullbyte = 0;
 
-int isEqual(u8* tid1, u8*tid2){
-	for(int i = 0; i < 8; i++){
-		if(tid1[i] != tid2[i]) return 0;
+int isEqual(u8 *tid1, u8 *tid2) {
+	for (int i = 0; i < 8; i++) {
+		if (tid1[i] != tid2[i]) { return 0; }
 	}
 	return 1;
 }
 
-int isAlreadyDumped(u8* titleid){
-	if(nKey == 0) return 0;
-	for(int i = 0; i < nKey; i++){
-		u8 *stored = TITLES + 8*i;
-		if(isEqual(stored, titleid)){
+int isAlreadyDumped(u8 *titleid) {
+	if (nKey == 0) { return 0; }
+	for (int i = 0; i < nKey; i++) {
+		u8 *stored = TITLES + 8 * i;
+		if (isEqual(stored, titleid)) {
 			return 1;
 		}
 	}
 	return 0;
 }
 
-unsigned int DecryptTitleKey(unsigned char* titleid, unsigned char* key, unsigned int index)
-{
+u32 DecryptTitleKey(u8 *titleid, u8 *key, u32 index) {
 	u8 ctr[16] __attribute__((aligned(32)));
 	u8 keyY[16] __attribute__((aligned(32)));
 	u8 titleId[8] __attribute__((aligned(32)));
 	memcpy(titleId, titleid, 8);
-
 	memset(ctr, 0, 16);
 	memcpy(ctr, titleId, 8);
-	set_ctr(AES_BIG_INPUT|AES_NORMAL_INPUT, ctr);
+	set_ctr(AES_BIG_INPUT | AES_NORMAL_INPUT, ctr);
 	memcpy(keyY, (void *) common_keyy[index], 16);
-	setup_aeskey(0x3D, AES_BIG_INPUT|AES_NORMAL_INPUT, keyY);
+	setup_aeskey(0x3D, AES_BIG_INPUT | AES_NORMAL_INPUT, keyY);
 	use_aeskey(0x3D);
 	aes_decrypt(key, key, ctr, 1, AES_CBC_DECRYPT_MODE);
 	return 0;
 }
 
-void DecryptTitleKeys(){
+void DecryptTitleKeys() {
 	ConsoleInit();
 	ConsoleSetTitle("Title Key Dumper");
-    File tick;
+	File tick;
 	File dump;
 	print("Opening ticket.db...\n"); ConsoleShow();
 	FileOpen(&dump, "rxTools/decTitleKeys.bin", 1);
-
-    unsigned int tick_size = 0xD0000;     //Chunk size
-    nKey = 0; int nullbyte = 0;
-    if(FileOpen(&tick, "1:dbs/ticket.db", 0)){
-        print("Decrypting title keys...\n"); ConsoleShow();
-        unsigned char* buf = 0x21000000;
-        int pos = 0;
-        for (;;) {
-            int rb = FileRead(&tick, buf, tick_size, pos);
-            if (rb == 0) break; /* error or eof */
-            pos += rb;
-            for(int j = 0; j < tick_size; j++){
-                if(!strcmp((char*)buf + j, "Root-CA00000003-XS0000000c")){
-                    u8 *titleid = buf + j + 0x9C;
-                    u32 kindex = *(buf + j + 0xB1);
-                    u8 Key[16]; memcpy(Key, BUF1 + j + 0x7F, 16);
-                    if( !isAlreadyDumped(titleid)){
-                        memcpy(TITLES + nKey*8, titleid, 8);
-                        FileWrite(&dump, &kindex, 4, 0x10 + nKey*0x20);
-                        FileWrite(&dump, &nullbyte, 4, 0x10 + nKey*0x20 + 4);
-                        FileWrite(&dump, titleid, 8, 0x10 + nKey*0x20 + 8);
-                        DecryptTitleKey(titleid, Key, kindex);
-                        FileWrite(&dump, Key, 16, 0x10 + nKey*0x20 + 16);
-                        nKey++;
-                    }
-                }
-            }
-        }
-        FileClose(&dump);
-        FileClose(&tick);
-    }else{
-        print("FAILURE!\n");
-    }
+	u32 tick_size = 0xD0000;     //Chunk size
+	nKey = 0; int nullbyte = 0;
+	if (FileOpen(&tick, "1:dbs/ticket.db", 0)) {
+		print("Decrypting title keys...\n"); ConsoleShow();
+		u8 *buf = 0x21000000;
+		int pos = 0;
+		for (;;) {
+			int rb = FileRead(&tick, buf, tick_size, pos);
+			if (rb == 0) { break; } /* error or eof */
+			pos += rb;
+			for (int j = 0; j < tick_size; j++) {
+				if (!strcmp((char *)buf + j, "Root-CA00000003-XS0000000c")) {
+					u8 *titleid = buf + j + 0x9C;
+					u32 kindex = *(buf + j + 0xB1);
+					u8 Key[16]; memcpy(Key, BUF1 + j + 0x7F, 16);
+					if (!isAlreadyDumped(titleid)) {
+						memcpy(TITLES + nKey * 8, titleid, 8);
+						FileWrite(&dump, &kindex, 4, 0x10 + nKey * 0x20);
+						FileWrite(&dump, &nullbyte, 4, 0x10 + nKey * 0x20 + 4);
+						FileWrite(&dump, titleid, 8, 0x10 + nKey * 0x20 + 8);
+						DecryptTitleKey(titleid, Key, kindex);
+						FileWrite(&dump, Key, 16, 0x10 + nKey * 0x20 + 16);
+						nKey++;
+					}
+				}
+			}
+		}
+		FileClose(&dump);
+		FileClose(&tick);
+	} else {
+		print("FAILURE!\n");
+	}
 	FileWrite(&dump, &nKey, 4, 0); FileWrite(&dump, &nullbyte, 4, 4); FileWrite(&dump, &nullbyte, 4, 8); FileWrite(&dump, &nullbyte, 4, 12);
 	FileClose(&dump);
 	print("\nPress A to exit\n"); ConsoleShow();
 	WaitForButton(BUTTON_A);
 }
 
-int GetTitleKey(unsigned char* TitleKey, unsigned int low, unsigned int high){
-    File tick;
-    unsigned int tid_low = ((low>>24)&0xff) | ((low<<8)&0xff0000) | ((low>>8)&0xff00) | ((low<<24)&0xff000000);
-    unsigned int tid_high = ((high>>24)&0xff) | ((high<<8)&0xff0000) | ((high>>8)&0xff00) | ((high<<24)&0xff000000);
-    unsigned int tick_size = 0x200;     //Chunk size
-    if(FileOpen(&tick, "1:dbs/ticket.db", 0)){
-        unsigned char* buf = 0x22000000;
-        int pos = 0;
-        for (;;) {
-            int rb = FileRead(&tick, buf, tick_size, pos);
-            if (rb == 0) break; /* error or eof */
-            pos += rb;
-            if(buf[0] == 'T' && buf[1] == 'I' && buf[2] == 'C' && buf[3] == 'K'){
-                tick_size = 0xD0000;
-                continue;
-            }
-            for(int j = 0; j < tick_size; j++){
-				if(!strcmp((char*)buf + j, "Root-CA00000003-XS0000000c")){
+int GetTitleKey(u8 *TitleKey, u32 low, u32 high) {
+	File tick;
+	u32 tid_low = ((low >> 24) & 0xff) | ((low << 8) & 0xff0000) | ((low >> 8) & 0xff00) | ((low << 24) & 0xff000000);
+	u32 tid_high = ((high >> 24) & 0xff) | ((high << 8) & 0xff0000) | ((high >> 8) & 0xff00) | ((high << 24) & 0xff000000);
+	u32 tick_size = 0x200;     //Chunk size
+	if (FileOpen(&tick, "1:dbs/ticket.db", 0)) {
+		u8 *buf = 0x22000000;
+		int pos = 0;
+		for (;;) {
+			int rb = FileRead(&tick, buf, tick_size, pos);
+			if (rb == 0) { break; } /* error or eof */
+			pos += rb;
+			if (buf[0] == 'T' && buf[1] == 'I' && buf[2] == 'C' && buf[3] == 'K') {
+				tick_size = 0xD0000;
+				continue;
+			}
+			for (int j = 0; j < tick_size; j++) {
+				if (!strcmp((char *)buf + j, "Root-CA00000003-XS0000000c")) {
 					u8 *titleid = buf + j + 0x9C;
 					u32 kindex = *(buf + j + 0xB1);
 					u8 Key[16]; memcpy(Key, buf + j + 0x7F, 16);
-					if( *((unsigned int*)titleid) == tid_low && *((unsigned int*)(titleid + 4)) == tid_high){
+					if (*((u32 *)titleid) == tid_low && *((u32 *)(titleid + 4)) == tid_high) {
 						DecryptTitleKey(titleid, Key, kindex);
 						memcpy(TitleKey, Key, 16);
 						FileClose(&tick);
-                        return 1;
+						return 1;
 					}
 				}
-            }
-        }
-        FileClose(&tick);
-    }
-    return 0;
+			}
+		}
+		FileClose(&tick);
+	}
+	return 0;
 }

--- a/rxtools/source/features/TitleKeyDecrypt.h
+++ b/rxtools/source/features/TitleKeyDecrypt.h
@@ -2,7 +2,7 @@
 #define TITLE_KEY_DECRYPT_H
 
 void DecryptTitleKeys();
-unsigned int DecryptTitleKey(unsigned char* titleid, unsigned char* key, unsigned int index);
-int GetTitleKey(unsigned char* TitleKey, unsigned int low, unsigned int high);
+u32 DecryptTitleKey(u8 *titleid, u8 *key, u32 index);
+int GetTitleKey(u8 *TitleKey, u32 low, u32 high);
 
 #endif

--- a/rxtools/source/features/TitleKeyDecrypt.h
+++ b/rxtools/source/features/TitleKeyDecrypt.h
@@ -1,7 +1,10 @@
 #ifndef TITLE_KEY_DECRYPT_H
 #define TITLE_KEY_DECRYPT_H
 
+#include "common.h"
+
 void DecryptTitleKeys();
+void DecryptTitleKeyFile(void);
 u32 DecryptTitleKey(u8 *titleid, u8 *key, u32 index);
 int GetTitleKey(u8 *TitleKey, u32 low, u32 high);
 

--- a/rxtools/source/features/nandtools.c
+++ b/rxtools/source/features/nandtools.c
@@ -29,7 +29,7 @@ static struct {
 
 static Menu CoolFilesMenu = {
 	"Choose the file to work on",
-	{
+	.Option = (MenuEntry[5]){
         " movable.sed", &SelectFile,
         " SecureInfo_A", &SelectFile,
         " LocalFriendCodeSeed_B", &SelectFile,

--- a/rxtools/source/lib/menu.h
+++ b/rxtools/source/lib/menu.h
@@ -11,7 +11,7 @@ typedef struct{
 
 typedef struct{
 	char* Name;
-	MenuEntry Option[1000];
+	MenuEntry* Option;
 	int nEntryes;
 	int Current;    //The current selected option
 	bool Showed;    //Useful, to not refresh everything everytime


### PR DESCRIPTION
Yes now it supports decryption of encTitleKeys.bin, which could be generated from something like 3DS_Multi_Decryptor. After generated xorpad for NAND partition and decrypted it, now i can get the decrypted title keys for my 9.8 Emunand. Also you can use this to decrypt other keys, surely.
I compacted MenuEntry in Menu, by easily cast its contents when initialized. See code, yup.