### PR TITLE
Fixed types, casts, not used vars which produced warnings (result binaries unchanged!)

### DIFF
--- a/brahma/data/payload/source/main.c
+++ b/brahma/data/payload/source/main.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-void* (*rxTools)() = 0x08000030;
+void* (*rxTools)() = (void*)0x08000030;
 
 void main()
 {
@@ -30,7 +30,7 @@ void main()
 	*((unsigned int*)0x080FFFC4) = 0x20046500;
 	*((unsigned int*)0x080FFFD8) = 0;
 
-	unsigned int* buf = 0x20400000;
+	unsigned int* buf = (void*)0x20400000;
 	unsigned int base = 0x67893421;
 	unsigned int seed = 0x12756342;
 	for(int i = 0; i < 400*1024/4; i++){
@@ -38,8 +38,8 @@ void main()
 		base += seed;
 	}
 
-	unsigned char*src = 0x20400000;
-	unsigned char*dst = 0x08000000;
+	unsigned char*src = (void*)0x20400000;
+	unsigned char*dst = (void*)0x08000000;
 	for(int i = 0; i < 320*1024; i++){
 		dst[i] = src[i];
 	}

--- a/msethax/payload/source/main.c
+++ b/msethax/payload/source/main.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-void* (*rxTools)() = 0x08000030;
+void* (*rxTools)() = (void*)0x08000030;
 
 void main()
 {
@@ -10,11 +10,11 @@ void main()
 	unsigned char* fb2 = (unsigned char*)(0x201CB370);
 	unsigned char pure_color = 0x77;
 	
-	*((unsigned int*)0x080FFFC0) = fb1;
-	*((unsigned int*)0x080FFFC4) = fb2;
+	*((unsigned int*)0x080FFFC0) = (int)fb1;
+	*((unsigned int*)0x080FFFC4) = (int)fb2;
 	*((unsigned int*)0x080FFFD8) = 0;
 	
-	unsigned int* buf = 0x20400000;
+	unsigned int* buf = (void*)0x20400000;
 	unsigned int base = 0x67893421;
 	unsigned int seed = 0x12756342;
 	for(int i = 0; i < 400*1024/4; i++){
@@ -24,8 +24,8 @@ void main()
 	
 	if(buf[0] != 0xE51FF004) pure_color = 0x00;
 	
-	unsigned char*src = 0x20400000;
-	unsigned char*dst = 0x08000000;
+	unsigned char*src = (void*)0x20400000;
+	unsigned char*dst = (void*)0x08000000;
 	for(int i = 0; i < 320*1024; i++){
 		dst[i] = src[i];
 	}

--- a/msethax/rxinstaller/source/main.cpp
+++ b/msethax/rxinstaller/source/main.cpp
@@ -18,7 +18,7 @@ u8 workbuffer[1024] ALIGN(32);
 using namespace std;
 
 typedef struct{
-	char* name;
+	const char* name;
 	const u8* patch;
 } rop_patch;
 

--- a/rxmode/native_firm/source/arm9/source/myThread/myThread.c
+++ b/rxmode/native_firm/source/arm9/source/myThread/myThread.c
@@ -24,17 +24,17 @@ void memdump(wchar_t* filename, unsigned char* buf, unsigned int size){
 }
 static unsigned char originalcode[] = { 0x00, 0x00, 0x55, 0xE3, 0x01, 0x10, 0xA0, 0xE3, 0x11, 0x00, 0xA0, 0xE1, 0x03, 0x00, 0x00, 0x0A };
 static unsigned char patchcode[] = { 0x01, 0x00, 0xA0, 0xE3, 0x70, 0x80, 0xBD, 0xE8 };
-static unsigned char* dest = 0x20000400;
+static char* dest = (void*)0x20000400;
 void patchregion(){
 	for(int i = 0; i < 8; i++) *(dest + i) = patchcode[i];
 }	
 
 void patch_processes(){
-	unsigned char* mset = 0x24000000;
-	unsigned char* menu = 0x26A00000;
+	char* mset = (void*)0x24000000;
+	char* menu = (void*)0x26A00000;
 	for(int i = 0; i < 0x600000; i+=4){
 		//System Menu code, which locks the region
-		if(dest == 0x20000400){	//This means we haven't still found our code
+		if(dest == (void*)0x20000400){	//This means we haven't still found our code
 			if( (*((unsigned int*)(menu + i + 0x0)) == *((unsigned int*)&originalcode[0x0])) &&
 				(*((unsigned int*)(menu + i + 0x4)) == *((unsigned int*)&originalcode[0x4])) &&
 				(*((unsigned int*)(menu + i + 0x8)) == *((unsigned int*)&originalcode[0x8])) &&

--- a/rxtools/source/MainMenu.h
+++ b/rxtools/source/MainMenu.h
@@ -28,11 +28,11 @@ static void ShutDown(){
 static Menu DecryptMenu = {
 	"Decryption Options",
 	{
-		" Decrypt CTR Titles", &CTRDecryptor,
-		" Decrypt Title Keys", &DecryptTitleKeys,
-		" Generate Xorpads", &PadGen,
-		" Decrypt partitions", &DumpNandPartitions,
-		" Generate fat16 Xorpad", &GenerateNandXorpads,
+		{" Decrypt CTR Titles", &CTRDecryptor},
+		{" Decrypt Title Keys", &DecryptTitleKeys},
+		{" Generate Xorpads", &PadGen},
+		{" Decrypt partitions", &DumpNandPartitions},
+		{" Generate fat16 Xorpad", &GenerateNandXorpads},
 	},
 	5,
 	0,
@@ -42,9 +42,9 @@ static Menu DecryptMenu = {
 static Menu DumpMenu = {
 	"Dumping Options",
 	{
-		" Create NAND dump", &NandDumper,
-		" Dump System Titles", &DumpNANDSystemTitles,
-		" Dump NAND Files", &dumpCoolFiles,
+		{" Create NAND dump", &NandDumper},
+		{" Dump System Titles", &DumpNANDSystemTitles},
+		{" Dump NAND Files", &dumpCoolFiles},
 	},
 	3,
 	0,
@@ -54,8 +54,8 @@ static Menu DumpMenu = {
 static Menu InjectMenu = {
 	"Injection Options",
 	{
-		" Inject EmuNAND partitions", &RebuildNand,
-		" Inject NAND Files", &restoreCoolFiles,
+		{" Inject EmuNAND partitions", &RebuildNand},
+		{" Inject NAND Files", &restoreCoolFiles},
 	},
 	2,
 	0,
@@ -65,9 +65,9 @@ static Menu InjectMenu = {
 static Menu ExploitMenu = {
 	"Other Options",
 	{
-		" Downgrade MSET on SysNAND", &downgradeMSET,
-		" Install FBI over Health&Safety App", &installFBI,
-		" Restore original Health&Safety App", &restoreHS,
+		{" Downgrade MSET on SysNAND", &downgradeMSET},
+		{" Install FBI over Health&Safety App", &installFBI},
+		{" Restore original Health&Safety App", &restoreHS},
 	},
 	3,
 	0,
@@ -146,13 +146,13 @@ static void Credits(){
 static Menu MainMenu = {
 		"rxTools - Roxas75 [v2.6]",
 		{
-			" Launch rxMode in EmuNAND", &rxModeEmu,
-			" Launch rxMode in SysNAND", &rxModeSys,
-			" Decryption Options", &DecryptMenuInit,
-			" Dumping Options", &DumpMenuInit,
-			" Injection Options", &InjectMenuInit,
-			" Other Options", &ExploitMenuInit,
-			" Credits", &Credits,
+			{" Launch rxMode in EmuNAND", &rxModeEmu},
+			{" Launch rxMode in SysNAND", &rxModeSys},
+			{" Decryption Options", &DecryptMenuInit},
+			{" Dumping Options", &DumpMenuInit},
+			{" Injection Options", &InjectMenuInit},
+			{" Other Options", &ExploitMenuInit},
+			{" Credits", &Credits},
 		},
 		7,
 		0,

--- a/rxtools/source/features/CTRDecryptor.c
+++ b/rxtools/source/features/CTRDecryptor.c
@@ -8,13 +8,13 @@
 #include "hid.h"
 #include "ncch.h"
 #include "crypto.h"
+#include "stdio.h"
 
-#define BUFFER_ADDR ((volatile u8*)0x21000000)
+#define BUFFER_ADDR ((u8*)0x21000000)
 #define BLOCK_SIZE  (8*1024*1024)
 
 
 u32 DecryptPartition(PartitionInfo* info){
-    size_t bytesWritten;
 	if(info->keyY != NULL)
 		setup_aeskey(info->keyslot, AES_BIG_INPUT|AES_NORMAL_INPUT, info->keyY);
     use_aeskey(info->keyslot);
@@ -67,7 +67,6 @@ void ProcessExeFS(PartitionInfo* info){ //We expect Exefs to take just a block. 
 int ProcessCTR(char* path){
 	PartitionInfo myInfo;
 	File myFile;
-	char myString[256];  //In case it is needed...
 	if(FileOpen(&myFile, path, 0)){
 		ConsoleInit();
 		ConsoleSetTitle("CTR Decryptor");
@@ -91,7 +90,7 @@ int ProcessCTR(char* path){
 		FileRead(&myFile, &NCCH, 0x200, ncch_base);
 
 		//print(path); print("\n"); 
-		print(NCCH.productcode); print("\n"); 
+		print((char*)NCCH.productcode); print("\n"); 
 		unsigned int NEWCRYPTO = 0, CRYPTO = 1;
 		if(NCCH.flags[3] != 0) NEWCRYPTO = 1;
 		if(NCCH.flags[7] & 4) CRYPTO = 0;

--- a/rxtools/source/features/NandDumper.c
+++ b/rxtools/source/features/NandDumper.c
@@ -9,10 +9,12 @@
 #include "crypto.h"
 #include "ncch.h"
 #include "CTRDecryptor.h"
+#include "sdmmc.h"
+#include "stdio.h"
 
 #define NAND_SIZE 0x3AF00000
 #define NAND_SECTOR_SIZE 0x200
-#define BUF1 0x21000000
+#define BUF1 (void*)0x21000000
 
 char myString[256];		//for showing percentages
 
@@ -39,11 +41,11 @@ void NandDumper(){
 	isEmuNand--;
 	ConsoleInit();
 	ConsoleSetTitle(isEmuNand ? "EmuNAND Dumper" : "NAND Dumper");
-	unsigned char* buf = 0x21000000;
+	unsigned char* buf = (void*)0x21000000;
 	unsigned int nsectors = 0x200;  //sectors in a row
 	char ProgressBar[] = "[                            ]";
 	unsigned int progress = 1;
-	int BACKCOLOR = ConsoleGetBackgroundColor();
+/*      int BACKCOLOR = */ConsoleGetBackgroundColor(); //can be removed, left only to keep binaries the same
 	if(FileOpen(&myFile, isEmuNand ? "rxTools/nand/EMUNAND.bin" : "rxTools/nand/NAND.bin", 1)){
 		print("Dumping...\n\n"); ConsoleShow();
 		int x, y; ConsoleGetXY(&x, &y); y += CHAR_WIDTH * 6; x += CHAR_WIDTH*2;

--- a/rxtools/source/features/TitleKeyDecrypt.c
+++ b/rxtools/source/features/TitleKeyDecrypt.c
@@ -72,7 +72,7 @@ void DecryptTitleKeys(){
     nKey = 0; int nullbyte = 0;
     if(FileOpen(&tick, "1:dbs/ticket.db", 0)){
         print("Decrypting title keys...\n"); ConsoleShow();
-        unsigned char* buf = 0x21000000;
+        unsigned char* buf = BUF1;
         int pos = 0;
         for (;;) {
             int rb = FileRead(&tick, buf, tick_size, pos);
@@ -112,7 +112,7 @@ int GetTitleKey(unsigned char* TitleKey, unsigned int low, unsigned int high){
     unsigned int tid_high = ((high>>24)&0xff) | ((high<<8)&0xff0000) | ((high>>8)&0xff00) | ((high<<24)&0xff000000);
     unsigned int tick_size = 0x200;     //Chunk size
     if(FileOpen(&tick, "1:dbs/ticket.db", 0)){
-        unsigned char* buf = 0x22000000;
+        unsigned char* buf = TITLES;
         int pos = 0;
         for (;;) {
             int rb = FileRead(&tick, buf, tick_size, pos);

--- a/rxtools/source/features/cfw.c
+++ b/rxtools/source/features/cfw.c
@@ -11,21 +11,20 @@
 #include "TitleKeyDecrypt.h"
 #include "configuration.h"
 
-#define FIRM_ADDR 0x24000000
+#define FIRM_ADDR (void*)0x24000000
 #define ARMBXR4	0x47204C00	
 
 char tmp[256];
 unsigned int emuNandMounted = 0;
-void (*_softreset)() = 0x080F0000;
+void (*_softreset)() = (void*)0x080F0000;
 
 void firmlaunch(u8* firm){
 	memcpy(FIRM_ADDR, firm, 0x200000); 	//Fixed size, no FIRM right now is that big
-	memcpy(0x080F0000, GetFilePack("reboot.bin"), 0x8000);
+	memcpy((void*)0x080F0000, GetFilePack("reboot.bin"), 0x8000);
 	_softreset();
 }
 
 void applyPatch(unsigned char* file, unsigned char* patch){
-	unsigned char* start = patch;
 	unsigned int ndiff = *((unsigned int*)patch); patch += 4;
 	for(int i = 0; i < ndiff; i++){
 		unsigned int off = *((unsigned int*)patch); patch += 4;
@@ -121,7 +120,7 @@ void rxModeQuickBoot(){
 
 //Just patches signatures check, loads in sysnand
 void DevMode(){
-    u8* firm = 0x24000000;
+    u8* firm = (void*)0x24000000;
     nand_readsectors(0, 0xF0000/0x200, firm, FIRM0);
     if(strncmp((char*)firm, "FIRM", 4))
     nand_readsectors(0, 0xF0000/0x200, firm, FIRM1);
@@ -139,6 +138,6 @@ void DevMode(){
             memcpy(firm + i, patch2, 2);
         }
     }
-    memcpy(0x080F0000, GetFilePack("reboot.bin"), 0x8000);
+    memcpy((void*)0x080F0000, GetFilePack("reboot.bin"), 0x8000);
 	_softreset();
 }

--- a/rxtools/source/features/configuration.c
+++ b/rxtools/source/features/configuration.c
@@ -22,7 +22,7 @@
 
 char tmpstr[256] = {0};
 File tmpfile;
-u32 tmpu32;
+UINT tmpu32;
 
 int InstallData(char* drive){
 	FIL firmfile;

--- a/rxtools/source/features/downgradeapp.c
+++ b/rxtools/source/features/downgradeapp.c
@@ -12,6 +12,8 @@
 #include "NandDumper.h"
 #include "aes.h"
 #include "polarssl/sha2.h"
+#include "stdio.h"
+#include "filepack.h"
 
 #define bswap_16(a) ((((a) << 8) & 0xff00) | (((a) >> 8) & 0xff))
 #define bswap_32(a) ((((a) << 24) & 0xff000000) | (((a) << 8) & 0xff0000) | (((a) >> 8) & 0xff00) | (((a) >> 24) & 0xff))
@@ -35,11 +37,11 @@ char cntpath[256]; // Contains the NAND content path
 char tmdpath[256]; // Contains the NAND TMD path
 
 char* getContentAppPath(){
-	return &cntpath;
+	return (char*)&cntpath;
 }
 
 char* getTMDAppPath(){
-	return &tmdpath;
+	return (char*)&tmdpath;
 }
 
 void print_sha256(unsigned char hash[32])
@@ -61,7 +63,7 @@ void print_sha256(unsigned char hash[32])
 
 int FindApp(unsigned int tid_low, unsigned int tid_high, int drive)
 {
-    char *folder = &tmpstr;
+    char *folder = (char*)&tmpstr;
     memset(folder, 0, 256);
 	
     DIR* curDir = &myDir;

--- a/rxtools/source/features/nandtools.c
+++ b/rxtools/source/features/nandtools.c
@@ -10,6 +10,7 @@
 #include "crypto.h"
 #include "ncch.h"
 #include "NandDumper.h"
+#include "stdio.h"
 
 #define nCoolFiles sizeof(CoolFiles)/sizeof(CoolFiles[0])
 
@@ -20,21 +21,21 @@ static struct {
     char* name;
     char* path;
 } CoolFiles[] = {
-    "movable.sed", "private/movable.sed",
-    "SecureInfo_A", "rw/sys/SecureInfo_A",
-    "LocalFriendCodeSeed_B", "rw/sys/LocalFriendCodeSeed_B",
-    "rand_seed", "rw/sys/rand_seed",
-    "ticket.db", "dbs/ticket.db",
+    {"movable.sed", "private/movable.sed"},
+    {"SecureInfo_A", "rw/sys/SecureInfo_A"},
+    {"LocalFriendCodeSeed_B", "rw/sys/LocalFriendCodeSeed_B"},
+    {"rand_seed", "rw/sys/rand_seed"},
+    {"ticket.db", "dbs/ticket.db"},
 };
 
 static Menu CoolFilesMenu = {
 	"Choose the file to work on",
 	{
-        " movable.sed", &SelectFile,
-        " SecureInfo_A", &SelectFile,
-        " LocalFriendCodeSeed_B", &SelectFile,
-        " rand_seed", &SelectFile,
-        " ticket.db", &SelectFile,
+        {" movable.sed", &SelectFile},
+        {" SecureInfo_A", &SelectFile},
+        {" LocalFriendCodeSeed_B", &SelectFile},
+        {" rand_seed", &SelectFile},
+        {" ticket.db", &SelectFile},
 	},
 	nCoolFiles,
 	0,

--- a/rxtools/source/features/padgen.c
+++ b/rxtools/source/features/padgen.c
@@ -21,7 +21,7 @@ void PadGen(){
 
 u32 NcchPadgen()
 {
-    size_t bytesRead;
+//    size_t bytesRead;
     u32 result;
 	File pf;
     NcchInfo *info = (NcchInfo*)0x20316000;
@@ -30,13 +30,13 @@ u32 NcchPadgen()
         print("Could not open ncchinfo.bin!\n");
         return 1;
     }
-    bytesRead = FileRead(&pf, info, 16, 0);
+/*    bytesRead = */FileRead(&pf, info, 16, 0);
 
     if (!info->n_entries || info->n_entries > MAXENTRIES || (info->ncch_info_version != 0xF0000003)) {
         print("Too many/few entries, or \nwrong version ncchinfo.bin!\n");
         return 0;
     }
-    bytesRead = FileRead(&pf, info->entries, info->n_entries * sizeof(NcchInfoEntry), 16);
+/*    bytesRead = */FileRead(&pf, info->entries, info->n_entries * sizeof(NcchInfoEntry), 16);
     FileClose(&pf);
 	
 	print("Working on ncchinfo.bin ...\n"); ConsoleShow();
@@ -123,7 +123,7 @@ u32 CreatePad(PadInfo *info, int index)
 File pf;
 #define BUFFER_ADDR ((volatile uint8_t*)0x21000000)
 #define BLOCK_SIZE  (4*1024*1024)
-    size_t bytesWritten;
+//    size_t bytesWritten;
 
     if (!FileOpen(&pf, info->filename, 1))
         return 1;
@@ -148,7 +148,7 @@ File pf;
 		
 		print("Creating Pad %i : %i%%      ", index, (i+j)/size_100);
 		ConsolePrevLine(); ConsolePrevLine(); ConsoleShow();
-		bytesWritten = FileWrite(&pf, (void*)BUFFER_ADDR, j, seekpos);
+/*		bytesWritten = */FileWrite(&pf, (void*)BUFFER_ADDR, j, seekpos);
         seekpos += j;
     }
 

--- a/rxtools/source/lib/console.c
+++ b/rxtools/source/lib/console.c
@@ -79,7 +79,7 @@ int findCursorLine(){
 	return cont;
 }
 void ConsoleShow(){
-	unsigned char* tmpscreen = 0x27000000;
+        void *tmpscreen = (void*)0x27000000;
 	memcpy(tmpscreen, TOP_SCREEN, 0x46500);
 	if(!consoleInited) return;
 	int titley = 2*CHAR_WIDTH;
@@ -90,9 +90,9 @@ void ConsoleShow(){
 			   (y >= ConsoleY && y <= ConsoleY + BorderWidth) || 
 			   (y >= ConsoleH + ConsoleY - 1 && y <= ConsoleH + ConsoleY - 1 + BorderWidth) ||
 			   (y >= ConsoleY + titley - BorderWidth && y <= ConsoleY + titley)){
-				DrawPixel(x, y, BorderColor, tmpscreen);
+				DrawPixel(x, y, BorderColor, (int)tmpscreen);
 			}else{
-				DrawPixel(x, y, BackgroundColor, tmpscreen);
+				DrawPixel(x, y, BackgroundColor, (int)tmpscreen);
 			}
 		}
 	}
@@ -100,7 +100,7 @@ void ConsoleShow(){
 	DrawString(tmpscreen, consoletitle, ConsoleX + BorderWidth + 2*CHAR_WIDTH, ConsoleY + (titlespace-CHAR_WIDTH)/2 + BorderWidth, TextColor, BackgroundColor);
 	
 	char tmp[256], *point;
-	if(findCursorLine < MAXLINES) point = &console[0];
+        if(findCursorLine < MAXLINES) point = &console[0]; //must be findCursorLine()?
 	else{
 		int cont = 0;
 		int tmp1;
@@ -134,7 +134,7 @@ void ConsoleFlush(){
 }
 
 void ConsoleAddText(char* str){
-    int linel = ((int)((float)(ConsoleW)/(float)CHAR_WIDTH))-5;
+//    int linel = ((int)((float)(ConsoleW)/(float)CHAR_WIDTH))-5;
     for(int i = 0; *str != 0x00; i++){
 		if(!(*str == '\\' && *(str+1) == 'n')){	//we just handle the '\n' case, who cares of the rest
 			console[cursor++] = *str++;

--- a/rxtools/source/lib/draw.c
+++ b/rxtools/source/lib/draw.c
@@ -153,9 +153,9 @@ void DrawPixel(int x, int y, int color, int screen){
     //Mind i ask why paint the pixel twice?
     //GCC: comparison between pointer and integer
     //GCC: assignment makes integer from pointer without a cast
-    if(screen == TOP_SCREEN && TOP_SCREEN2){
+    if((void*)screen == TOP_SCREEN && TOP_SCREEN2){
         if(color != TRANSPARENT){
-	        int address = TOP_SCREEN2 + (SCREEN_HEIGHT * (x + 1) - y) * BYTES_PER_PIXEL;
+	        int address = (int)TOP_SCREEN2 + (SCREEN_HEIGHT * (x + 1) - y) * BYTES_PER_PIXEL;
     		writeByte(address, color);
     		writeByte(address+1, color >> 8);
     		writeByte(address+2, color >>16);

--- a/rxtools/source/lib/fatfs/diskio.c
+++ b/rxtools/source/lib/fatfs/diskio.c
@@ -56,14 +56,14 @@ DRESULT disk_read (
 {
     switch(pdrv){
         case 0:
-            if (sdmmc_sdcard_readsectors(sector,count,buff))
+            if (sdmmc_sdcard_readsectors(sector,count,(uint8_t *)buff))
                 return RES_PARERR;
             break;
         case 1:
-            nand_readsectors(sector, count, buff, CTRNAND);
+            nand_readsectors(sector, count, (uint8_t *)buff, CTRNAND);
             break;
         case 2:
-            emunand_readsectors(sector, count, buff, CTRNAND);
+            emunand_readsectors(sector, count, (uint8_t *)buff, CTRNAND);
             break;
     }
     return RES_OK;

--- a/rxtools/source/lib/filepack.c
+++ b/rxtools/source/lib/filepack.c
@@ -5,7 +5,7 @@
 #include "CTRDecryptor.h"
 #include "console.h"
 
-#define FILEPACK_ADDR	0x20400000
+#define FILEPACK_ADDR	(void*)0x20400000
 #define FILEPACK_OFF	0x100000			//Offset in Launcher.dat
 #define FILEPACK_SIZE	0x100000
 
@@ -28,8 +28,8 @@ void LoadPack(){
 	nEntry = *((unsigned int*)(FILEPACK_ADDR));
 	Entry = ((PackEntry*)(FILEPACK_ADDR + 0x10));
 	for(int i = 0; i < nEntry; i++){
-		Entry[i].off += FILEPACK_ADDR;
-		if(!CheckHash(Entry[i].off, Entry[i].size, Entry[i].hash)){
+		Entry[i].off += (int)FILEPACK_ADDR;
+		if(!CheckHash((void*)Entry[i].off, Entry[i].size, Entry[i].hash)){
 			DrawString(TOP_SCREEN, " rxTools.dat is corrupted!", 0, 240-8, BLACK, WHITE); 		//Who knows, if there is any corruption in our files, we need to stop
 			while(1);
 		}

--- a/rxtools/source/lib/hid.c
+++ b/rxtools/source/lib/hid.c
@@ -1,4 +1,5 @@
 #include "hid.h"
+#include "screenshot.h"
 
 u32 InputWait() {
     u32 pad_state_old = HID_STATE;

--- a/rxtools/source/lib/i2c.c
+++ b/rxtools/source/lib/i2c.c
@@ -3,7 +3,7 @@
 
 //-----------------------------------------------------------------------------
 
-static const struct { u8 bus_id, reg_addr } dev_data[] = {
+static const struct { u8 bus_id, reg_addr; } dev_data[] = {
     {0, 0x4A}, {0, 0x7A}, {0, 0x78},
     {1, 0x4A}, {1, 0x78}, {1, 0x2C},
     {1, 0x2E}, {1, 0x40}, {1, 0x44},

--- a/rxtools/source/lib/screenshot.c
+++ b/rxtools/source/lib/screenshot.c
@@ -5,6 +5,7 @@
 #include "hid.h"
 #include "fs.h"
 #include "ff.h"
+#include "stdio.h"
 
 unsigned char bmpTopHeader[] = {	
 	0x42, 0x4D, 0x36, 0x65, 0x04, 0x00, 0x00, 0x00, 
@@ -27,9 +28,9 @@ void ScreenShot(){
 	if(FileOpen(&myFile, tmp, 1)){
 		FileWrite(&myFile, bmpTopHeader, 0x36, 0);
 		int pos = 0x36;
-		for(int i = 240-1; i >= 0; i--){
-			for(int j = 0; j < 400; j++){
-				int color = GetPixel(j, i, TOP_SCREEN);
+		for(int i = SCREEN_HEIGHT-1; i >= 0; i--){
+			for(int j = 0; j < SCREEN_WIDTH; j++){
+				int color = GetPixel(j, i, (int)TOP_SCREEN);
 				FileWrite(&myFile, &color, 0x4, pos);
 				pos += 3;
 			}
@@ -39,7 +40,7 @@ void ScreenShot(){
 }
 
 void TryScreenShot(){
-	u32 pad = GetInput();
+/*	u32 pad = */GetInput();
 	//if(pad & BUTTON_L1 && pad & BUTTON_R1) ScreenShot();
 	//Disabled, i don't need any screenshot for now, but the function is here
 }

--- a/tools/toolsrc/cfwtool/main.c
+++ b/tools/toolsrc/cfwtool/main.c
@@ -9,21 +9,23 @@
 */
 
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <dirent.h>
 #include <unistd.h>
 #define MAX_PATCHES 100
 
 typedef struct{
 	char* name;
-	int arm9_addr;
-	int arm9_size;
-	int arm9_entry;
-	int arm11_addr;
-	int arm11_size;
-	int arm11_entry;
-	int p9_addr;
-	int p9_start;
-	int p9_entry;
+        unsigned arm9_addr;
+        unsigned arm9_size;
+        unsigned arm9_entry;
+        unsigned arm11_addr;
+        unsigned arm11_size;
+        unsigned arm11_entry;
+        unsigned p9_addr;
+        unsigned p9_start;
+        unsigned p9_entry;
 } firm_info;
 
 firm_info native_info = { "NATIVE_FIRM", 0x66000, 0x84A00, 0x08006800, 0x35000, 0x31000, 0x1FF80000, 0x15B00, 0x16700, 0x08028000};
@@ -57,6 +59,7 @@ int listfiles(char* curDir){
 		}
 		closedir (dir);
 		printf("Patches folder : %s\nNumber of patches : %d\n", curDir, npatch);
+		return 0;
 	} else {
 		return -1;
 	}

--- a/tools/toolsrc/pack_tool/main.c
+++ b/tools/toolsrc/pack_tool/main.c
@@ -17,8 +17,8 @@ typedef struct{
 
 unsigned int HashGen(unsigned char* file, unsigned int size){  //that's the simplest and crappiest hash engine i could invent
 	unsigned int HASH = 0;							  //but it works, so i don't give a shit
-	int i;
-	for(i = 0; i < size - 4; i++){
+	unsigned int i;
+	for(i = 0; i + 4 < size; i++){
 		HASH ^= file[i];
 		HASH ^= file[i+1] << 8;
 		HASH ^= file[i+2] << 16;
@@ -37,14 +37,14 @@ char* getFileName(char* fn){
 }
 
 int main(int argc, char** argv){
-	int i;
+	unsigned int i;
 	if(argc < 3) return -1;
 	FILE* out = fopen(argv[argc-1], "wb");
 	if(!out){
 		printf("Cannot create %s!\n", argv[argc-1]);
 		return -1;
 	}
-	int nfiles = argc - 2;
+	unsigned int nfiles = argc - 2;
 	if(nfiles == 0){
 		printf("No files specified to pack!");
 	}


### PR DESCRIPTION
Several casts could be avoided by changing prototypes to use void* where typed (or pointer) vars not needed, but intentionally left untouched with this commit to keep compiled binaries unchanged.