### PR TITLE
Use $(MAKE) instead of make in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ distclean: clean
 
 .PHONY: clean
 clean:
-	@make -C rxtools clean
-	@make -C rxmode clean
-	@make -C brahma clean
-	@make -C msethax clean
+	@$(MAKE) -C rxtools clean
+	@$(MAKE) -C rxmode clean
+	@$(MAKE) -C brahma clean
+	@$(MAKE) -C msethax clean
 	@rm -f $(tools) payload.bin data.bin rxTools.dat
 
 .PHONY: release
@@ -36,11 +36,11 @@ rxTools.dat: payload.bin rxmode/*.bin data.bin msethax/mset.bin
 
 .PHONY: brahma/brahma.3dsx brahma/brahma.smdh
 brahma/brahma.3dsx brahma/brahma.smdh:
-	make -C $(dir $@) all
+	$(MAKE) -C $(dir $@) all
 
 .PHONY: msethax/mset.bin
 msethax/mset.bin:
-	make -C $(dir $@) all
+	$(MAKE) -C $(dir $@) all
 
 data.bin: tools/pack_tool tools/xor
 	@tools/pack_tool $(DATA_FILES) $@
@@ -50,14 +50,14 @@ data.bin: tools/pack_tool tools/xor
 
 .PHONY: rxmode/*.bin
 rxmode/*.bin: tools/cfwtool
-	@cd rxmode && make
+	@cd rxmode && $(MAKE)
 
 payload.bin: rxtools/rxtools.bin tools/addxor_tool
 	@tools/addxor_tool $< $@ 0x67893421 0x12756342
 
 .PHONY: rxtools/rxtools.bin
 rxtools/rxtools.bin: tools/addxor_tool
-	@make -C $(dir $@) all
+	@$(MAKE) -C $(dir $@) all
 	@dd if=$@ of=$@ bs=896K count=1 conv=sync,notrunc
 
 $(tools): tools/%: tools/toolsrc/%/main.c

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-PYTHON = python
-
 CFLAGS = -std=c11 -O2 -Wall -Wextra
 
 tools = tools/addxor_tool tools/cfwtool tools/pack_tool tools/xor

--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,14 @@ clean:
 	@rm -f $(tools) payload.bin data.bin rxTools.dat
 
 .PHONY: release
-release: rxTools.dat brahma/brahma.3dsx brahma/brahma.smdh
+release: rxTools.dat brahma/brahma.3dsx brahma/brahma.smdh all-target-mset
 	@mkdir -p release/mset release/ninjhax
 	@cp rxTools.dat release
 	@cp brahma/brahma.3dsx release/ninjhax/rxtools.3dsx
 	@cp brahma/brahma.smdh release/ninjhax/rxtools.smdh
 	@cp msethax/rxinstaller.nds release/mset/rxinstaller.nds
 
-rxTools.dat: payload.bin rxmode/*.bin data.bin msethax/mset.bin
+rxTools.dat: payload.bin data.bin all-target-mset
 	@dd if=spiderhax/Launcher.dat of=$@ bs=4M conv=sync
 	@dd if=msethax/mset.bin of=$@ conv=notrunc
 	@dd if=payload.bin of=$@ seek=256 conv=notrunc
@@ -38,18 +38,20 @@ rxTools.dat: payload.bin rxmode/*.bin data.bin msethax/mset.bin
 brahma/brahma.3dsx brahma/brahma.smdh:
 	$(MAKE) -C $(dir $@) all
 
-.PHONY: msethax/mset.bin
-msethax/mset.bin:
-	$(MAKE) -C $(dir $@) all
+.PHONY: all-target-mset
+all-target-mset:
+	$(MAKE) -C msethax all
 
-data.bin: tools/pack_tool tools/xor
-	@tools/pack_tool $(DATA_FILES) $@
+data.bin: $(DATA_FILES) tools/pack_tool tools/xor
+	@tools/pack_tool $< $@
 	@tools/xor $@ tools/xorpad/data.xor
 	@rm $@
 	@mv $@.out $@
 
-.PHONY: rxmode/*.bin
-rxmode/*.bin: tools/cfwtool
+.PHONY: rxmode/%.bin
+rxmode/%.bin: all-target-rxmode
+
+all-target-rxmode: tools/cfwtool
 	@cd rxmode && $(MAKE)
 
 payload.bin: rxtools/rxtools.bin tools/addxor_tool

--- a/brahma/Makefile
+++ b/brahma/Makefile
@@ -124,15 +124,15 @@ all: payload.bin $(BUILD)
 $(BUILD):
 	@echo $(SFILES)
 	@[ -d $@ ] || mkdir -p $@
-	@make --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 
 payload.bin :
-	@cd data/payload && make
+	@cd data/payload && $(MAKE)
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
 	@rm -fr $(BUILD) $(TARGET).3dsx $(OUTPUT).smdh $(TARGET).elf
-	@cd data/payload && make clean
+	@cd data/payload && $(MAKE) clean
 
 #---------------------------------------------------------------------------------
 else

--- a/brahma/data/payload/Makefile
+++ b/brahma/data/payload/Makefile
@@ -100,7 +100,7 @@ all: $(BUILD)
 
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
-	@make --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
  
 #---------------------------------------------------------------------------------
 clean:

--- a/data/reboot/Makefile
+++ b/data/reboot/Makefile
@@ -100,7 +100,7 @@ all: $(BUILD)
 
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
-	@make --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 	
  
 #---------------------------------------------------------------------------------

--- a/msethax/Makefile
+++ b/msethax/Makefile
@@ -21,11 +21,11 @@ KEY2   = 0160A0E14ADF4DE2EC109FE50250A0E1
 all: rxinstaller.nds arm9_code.bin mset.bin
 
 rxinstaller.nds:
-	@cd rxinstaller && make
+	@cd rxinstaller && $(MAKE)
 
 arm9_code.bin:
 	@mkdir -p $(BUILD)
-	@cd payload && make
+	@cd payload && $(MAKE)
 	@mv payload.bin build/arm9_code.bin
 
 mset.bin:
@@ -36,6 +36,6 @@ mset.bin:
 
 clean:
 	@echo clean ...
-	@cd rxinstaller && make clean
-	@cd payload && make clean
+	@cd rxinstaller && $(MAKE) clean
+	@cd payload && $(MAKE) clean
 	@rm -fr $(BUILD) *.nds *.bin

--- a/msethax/payload/Makefile
+++ b/msethax/payload/Makefile
@@ -100,7 +100,7 @@ all: $(BUILD)
 
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
-	@make --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 	@rm $(OUTPUT).elf
 	
 #---------------------------------------------------------------------------------

--- a/msethax/rxinstaller/Makefile
+++ b/msethax/rxinstaller/Makefile
@@ -165,7 +165,7 @@ data/mset6x.bin: rop/mset6x.s
 	
 $(BUILD):
 	@mkdir -p $@
-	@make --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 	@rm $(OUTPUT).elf
 
 #---------------------------------------------------------------------------------

--- a/rxmode/Makefile
+++ b/rxmode/Makefile
@@ -10,20 +10,20 @@ endif
 all: nat_patch.bin agb_patch.bin twl_patch.bin
 
 nat_patch.bin:
-	@cd native_firm && make
+	@cd native_firm && $(MAKE)
 	@cp native_firm/patch.bin $@
 	
 agb_patch.bin:
-	@cd agb_firm && make
+	@cd agb_firm && $(MAKE)
 	@cp agb_firm/patch.bin $@
 
 twl_patch.bin:
-	@cd twl_firm && make
+	@cd twl_firm && $(MAKE)
 	@cp twl_firm/patch.bin $@
 	
 clean:
 	@echo clean ...
-	@cd native_firm && make clean
-	@cd agb_firm && make clean
-	@cd twl_firm && make clean
+	@cd native_firm && $(MAKE) clean
+	@cd agb_firm && $(MAKE) clean
+	@cd twl_firm && $(MAKE) clean
 	@rm -fr $(BUILD) *.bin

--- a/rxmode/native_firm/Makefile
+++ b/rxmode/native_firm/Makefile
@@ -22,7 +22,7 @@ $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
 	
 arm9payload.bin:
-	@cd source/arm9 && make
+	@cd source/arm9 && $(MAKE)
 	
 patch.bin:
 	@$(foreach sfile,$(SFILES), $(ARMIPS) $(sfile);)

--- a/rxmode/native_firm/source/arm9/source/myThread/myThread.c
+++ b/rxmode/native_firm/source/arm9/source/myThread/myThread.c
@@ -10,7 +10,7 @@
 #ifdef MEMDUMP
 unsigned char handle[32];
 
-void memdump(wchar_t* filename, unsigned char* buf, unsigned int size){
+static void memdump(wchar_t* filename, unsigned char* buf, unsigned int size){
 	unsigned int br;
 	memset(VRAM, 0x77, 0x600000);			//Grey flush : Start Dumping
 	memset(&handle, 0, 32);
@@ -24,11 +24,11 @@ void memdump(wchar_t* filename, unsigned char* buf, unsigned int size){
 static unsigned char originalcode[] = { 0x00, 0x00, 0x55, 0xE3, 0x01, 0x10, 0xA0, 0xE3, 0x11, 0x00, 0xA0, 0xE1, 0x03, 0x00, 0x00, 0x0A };
 static unsigned char patchcode[] = { 0x01, 0x00, 0xA0, 0xE3, 0x70, 0x80, 0xBD, 0xE8 };
 static char* dest = (void*)0x20000400;
-void patchregion(){
+static void patchregion(){
 	for(int i = 0; i < 8; i++) *(dest + i) = patchcode[i];
 }	
 
-void patch_processes(){
+static void patch_processes(){
 	char* mset = (void*)0x24000000;
 	char* menu = (void*)0x26A00000;
 	for(int i = 0; i < 0x600000; i+=4){

--- a/rxmode/native_firm/source/arm9/source/myThread/myThread.c
+++ b/rxmode/native_firm/source/arm9/source/myThread/myThread.c
@@ -7,6 +7,7 @@
 #include <wchar.h>
 #include <stdio.h>
 
+#ifdef MEMDUMP
 unsigned char handle[32];
 
 void memdump(wchar_t* filename, unsigned char* buf, unsigned int size){
@@ -18,6 +19,8 @@ void memdump(wchar_t* filename, unsigned char* buf, unsigned int size){
 	fclose9(&handle);
 	memset(VRAM, 0xFF, 0x600000);			//White flush : Finished Dumping
 }
+#endif
+
 static unsigned char originalcode[] = { 0x00, 0x00, 0x55, 0xE3, 0x01, 0x10, 0xA0, 0xE3, 0x11, 0x00, 0xA0, 0xE1, 0x03, 0x00, 0x00, 0x0A };
 static unsigned char patchcode[] = { 0x01, 0x00, 0xA0, 0xE3, 0x70, 0x80, 0xBD, 0xE8 };
 static char* dest = (void*)0x20000400;
@@ -48,9 +51,11 @@ void patch_processes(){
 
 void myThread(){
 	while(1){
-		/*if(getHID() & BUTTON_SELECT){
+#ifdef MEMDUMP
+		if(getHID() & BUTTON_SELECT){
 			memdump(L"sdmc:/FCRAM.bin", 0x20000000, 0x10000);
-		}*/
+		}
+#endif
 		patch_processes();
 		if(*((unsigned int*)dest) != *((unsigned int*)&patchcode[0]))
 			svc_Backdoor(&patchregion);		//Edit just if the code is not patched, or the arm9 will get mad

--- a/rxmode/native_firm/source/arm9/source/myThread/myThread.c
+++ b/rxmode/native_firm/source/arm9/source/myThread/myThread.c
@@ -6,6 +6,7 @@
 #include "FS.h"
 #include <wchar.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #ifdef MEMDUMP
 unsigned char handle[32];
@@ -21,30 +22,30 @@ static void memdump(wchar_t* filename, unsigned char* buf, unsigned int size){
 }
 #endif
 
-static unsigned char originalcode[] = { 0x00, 0x00, 0x55, 0xE3, 0x01, 0x10, 0xA0, 0xE3, 0x11, 0x00, 0xA0, 0xE1, 0x03, 0x00, 0x00, 0x0A };
-static unsigned char patchcode[] = { 0x01, 0x00, 0xA0, 0xE3, 0x70, 0x80, 0xBD, 0xE8 };
-static char* dest = (void*)0x20000400;
+static int32_t originalcode[] = { 0xE3550000, 0xE3A01001, 0xE1A00011, 0x0A000003 };
+static int32_t patchcode[] = { 0xE3A00001, 0xE8BD8070 };
+static int32_t* dest = (void*)0x20000400;
 static void patchregion(){
-	for(int i = 0; i < 8; i++) *(dest + i) = patchcode[i];
+	for(int i = 0; i < 8 / sizeof(int32_t); i++) dest[i] = patchcode[i];
 }	
 
 static void patch_processes(){
-	char* mset = (void*)0x24000000;
-	char* menu = (void*)0x26A00000;
-	for(int i = 0; i < 0x600000; i+=4){
+	const uintptr_t mset = 0x24000000;
+	const uintptr_t menu = 0x26A00000;
+	for(int i = 0; i < 0x600000; i++){
 		//System Menu code, which locks the region
 		if(dest == (void*)0x20000400){	//This means we haven't still found our code
-			if( (*((unsigned int*)(menu + i + 0x0)) == *((unsigned int*)&originalcode[0x0])) &&
-				(*((unsigned int*)(menu + i + 0x4)) == *((unsigned int*)&originalcode[0x4])) &&
-				(*((unsigned int*)(menu + i + 0x8)) == *((unsigned int*)&originalcode[0x8])) &&
-				(*((unsigned int*)(menu + i + 0xC)) == *((unsigned int*)&originalcode[0xC]))){	
-				dest = menu + i;    //Basically, once we found where the code is, there is no point on searching it again
+			if( ((*((int32_t *)(menu + i + 0x0)) == originalcode[0]) &&
+				((*((int32_t *)(menu + i + 1))) == originalcode[1]) &&
+				((*((int32_t *)(menu + i + 2))) == originalcode[2]) &&
+				((*((int32_t *)(menu + i + 3))) == originalcode[3]))){	
+				dest = (int32_t *)(menu + i);    //Basically, once we found where the code is, there is no point on searching it again
 				break;
 			}
 		}
 		//System Settings label
-		if(rx_strcmp(mset - i, "Ver.", 4, 2, 1)){
-			rx_strcpy(mset - i, "Shit", 4, 2, 1);
+		if(rx_strcmp((char *)mset - i, "Ver.", 4, 2, 1)){
+			rx_strcpy((char *)mset - i, "Shit", 4, 2, 1);
 		}
 	}
 }
@@ -57,7 +58,7 @@ void myThread(){
 		}
 #endif
 		patch_processes();
-		if(*((unsigned int*)dest) != *((unsigned int*)&patchcode[0]))
+		if(*dest != patchcode[0])
 			svc_Backdoor(&patchregion);		//Edit just if the code is not patched, or the arm9 will get mad
 	}
 	__asm("SVC 0x09");

--- a/rxmode/native_firm/source/arm9/source/myThread/myThread.c
+++ b/rxmode/native_firm/source/arm9/source/myThread/myThread.c
@@ -11,16 +11,12 @@ unsigned char handle[32];
 
 void memdump(wchar_t* filename, unsigned char* buf, unsigned int size){
 	unsigned int br;
-	for(int i = 0; i < 0x600000; i++){
-		*(VRAM + i) = 0x77;			//Grey flush : Start Dumping
-	}
+	memset(VRAM, 0x77, 0x600000);			//Grey flush : Start Dumping
 	memset(&handle, 0, 32);
 	fopen9(&handle, filename, 6);
 	fwrite9(&handle, &br, buf, size);
 	fclose9(&handle);
-	for(int i = 0; i < 0x600000; i++){
-		*(VRAM + i) = 0xFF;			//White flush : Finished Dumping
-	}
+	memset(VRAM, 0xFF, 0x600000);			//White flush : Finished Dumping
 }
 static unsigned char originalcode[] = { 0x00, 0x00, 0x55, 0xE3, 0x01, 0x10, 0xA0, 0xE3, 0x11, 0x00, 0xA0, 0xE1, 0x03, 0x00, 0x00, 0x0A };
 static unsigned char patchcode[] = { 0x01, 0x00, 0xA0, 0xE3, 0x70, 0x80, 0xBD, 0xE8 };

--- a/rxtools/Makefile
+++ b/rxtools/Makefile
@@ -101,7 +101,7 @@ all: $(BUILD)
 
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
-	@make --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 	
 	@rm -fr $(OUTPUT).elf
 


### PR DESCRIPTION
$(MAKE) has many advantages to just calling make.
See this page for the detail.
https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html#MAKE-Variable