### PR TITLE
Add rxTools/source/lib/font.h to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ Temporary Items
 **/build
 **/data
 release.zip
+rxtools/source/font.h


### PR DESCRIPTION
Add font.h to ignore list for GitHub. This file is only generated during compile and probably shouldn't be synced on github. ;)