### PR TITLE
Move Native_Firm file creation to rxtools/data...

### DIFF
--- a/rxtools/source/features/firm.c
+++ b/rxtools/source/features/firm.c
@@ -306,7 +306,7 @@ int rxMode(int emu)
 		}
 	}
 
-	f_open(&fd, "NATIVE_FIRM.BIN", FA_WRITE | FA_CREATE_ALWAYS);
+	f_open(&fd, "rxtools/data/NATIVE_FIRM.BIN", FA_WRITE | FA_CREATE_ALWAYS);
 	f_write(&fd, (void *)FIRM_ADDR, 0x200000, &br);
 	f_close(&fd);
 


### PR DESCRIPTION
Currently it just gets created at SD root. This will reduce the clutter. I tested this and it works fine for me.