### PR TITLE
memcpy32 fix, with home menu memory range fixed again

### DIFF
--- a/rxmode/native_firm/source/payload/arm9/myThread/myThread.c
+++ b/rxmode/native_firm/source/payload/arm9/myThread/myThread.c
@@ -194,7 +194,7 @@ static void *memcpy32(void *dst, const void *src, size_t n)
 
 		_dst++;
 		_src++;
-		n--;
+		n -= sizeof(int);
 	}
 
 	return dst;
@@ -209,7 +209,7 @@ static void findRegion()
 {
 	uintptr_t p;
 
-	for (p = 0x26980000; p < 0x27000000; p += 4)
+	for (p = 0x26960000; p < 0x26B00000; p += 4)
 		if (!memcmp32((void *)p, originalcode, sizeof(originalcode))) {
 			dest = (void *)p;
 			break;


### PR DESCRIPTION
I did fcram dump for some firmwares and found that its code seg always starts from 0x26960000-0x269A0000 and takes about 0x110000 bytes, so I changed patch search range to these values.