### PR TITLE
Shorten auto boot time for rxMode...

### DIFF
--- a/rxtools/source/main.c
+++ b/rxtools/source/main.c
@@ -121,7 +121,7 @@ int Initialize()
 
 			for (int i = 0; i < 0x333333 * 2; i++){
 				uint32_t pad = GetInput();
-				if (pad & BUTTON_R1 && i > 0x333333) goto rxTools_boot;
+				if (pad & BUTTON_R1 && i > 0x111111) goto rxTools_boot;
 			}
 		}
 		else


### PR DESCRIPTION
Shorten time rxTools waits before booting default rxMode emunand. 3 second seems a bit long to wait. Would help folks who don't want to enable the quick boot option as one currently has to manually modify the settings file back if they wanted to get back into the rxTools menu for something. :P

I've tested this before and shortening it to something slightly longer then a second is more then enough time to trigger R button when needing to use the menus.