### PR TITLE
Support SDinfo.dat and ncchinfo.dat from 3DS_Multi_Decryptor

### DIFF
--- a/rxtools/source/features/padgen.c
+++ b/rxtools/source/features/padgen.c
@@ -155,7 +155,18 @@ uint32_t CreatePad(PadInfo *info, int index)
 	#define BUFFER_ADDR ((volatile uint8_t*)0x21000000)
 	#define BLOCK_SIZE  (4*1024*1024)
 
-	if (!FileOpen(&pf, info->filename, 1))
+	if(info->filename[0] != 0 && info->filename[1] == 0 && info->filename[2] != 0 && info->filename[3] == 0)
+	{
+		char fname[90];
+		for(int i = 0; i < 90; ++i)
+		{
+			fname[i] = info->filename[i*2];
+			if(fname[i] == 0) break;
+		}
+		if (!FileOpen(&pf, strncmp(fname, "sdmc:/", 6) == 0 ? fname + 6 : fname, 1))
+			return 1;
+	}
+	else if (!FileOpen(&pf, info->filename, 1))
 		return 1;
 
 	if(info->setKeyY != 0)


### PR DESCRIPTION
3DS_Multi_Decrytor uses unicode filename in SDinfo.dat and ncchinfo.dat, I did a liitle trick to detect them.