### PR TITLE
Ported rxTools to brahma2

### DIFF
--- a/brahma/source/arm11.s
+++ b/brahma/source/arm11.s
@@ -96,7 +96,7 @@ wait_arm11_loop:
 	BX              R1
 
 	pa_hijack_arm9_dst:  .long 0x1FFFFC00
-	pa_arm11_code:       .long 0x1FFFFFF8
+	pa_arm11_code:       .long 0x1FFFFFFC
 	pa_pxi_regs:         .long 0x10163000
 	some_pxi_cmd:        .long 0x44846
 	pa_firm_header:      .long 0x24000000

--- a/brahma/source/arm11.s
+++ b/brahma/source/arm11.s
@@ -96,7 +96,7 @@ wait_arm11_loop:
 	BX              R1
 
 	pa_hijack_arm9_dst:  .long 0x1FFFFC00
-	pa_arm11_code:       .long 0x1FFFFFFC
+	pa_arm11_code:       .long 0x1FFFFFF8
 	pa_pxi_regs:         .long 0x10163000
 	some_pxi_cmd:        .long 0x44846
 	pa_firm_header:      .long 0x24000000

--- a/brahma/source/brahma.c
+++ b/brahma/source/brahma.c
@@ -41,9 +41,10 @@ void do_gshax_copy (void *dst, void *src, u32 len) {
 	u32 check_mem = linearMemAlign(0x10000, 0x40);
 	s32 i = 0;
 
-	for (i = 0; i < 16; ++i) {
+	for (i = 0; i < 20; ++i) {
 		GSPGPU_FlushDataCache (NULL, src, len);
 		GX_SetTextureCopy(NULL, src, 0, dst, 0, len, 8);
+		svcSleepThread(0x400000LL);
 		GSPGPU_FlushDataCache (NULL, check_mem, 16);
 		GX_SetTextureCopy(NULL, src, 0, check_mem, 0, 0x40, 8);
 	}
@@ -119,13 +120,11 @@ void priv_write_four (u32 address) {
 // trick to clear icache
 void user_clear_icache (void) {
 	s32 i;
-	for(i = 0; i < 5; i++)
+	for(i = 0; i < 16; i++)
 	{
 		//Fills the top screen with random data
 		do_gshax_copy(0x14000000, 0x18000000, 0x46500);
-		svcSleepThread(0x400000LL);
 		do_gshax_copy(0x14046500, 0x18000000, 0x46500);
-		svcSleepThread(0x400000LL);
 	}
 }
 

--- a/brahma/source/brahma.c
+++ b/brahma/source/brahma.c
@@ -47,7 +47,6 @@ void do_gshax_copy (void *dst, void *src, u32 len) {
 		GSPGPU_FlushDataCache (NULL, check_mem, 16);
 		GX_SetTextureCopy(NULL, src, 0, check_mem, 0, 0x40, 8);
 	}
-	HB_FlushInvalidateCache();
 	linearFree(check_mem);
 	return;
 }
@@ -119,24 +118,15 @@ void priv_write_four (u32 address) {
 
 // trick to clear icache
 void user_clear_icache (void) {
-	s32 i, result = 0;
-	s32 (*nop_func)(void);
-	const u32 size_nopslide = 0x1000;	
-	u32 *nop_slide = memalign(0x1000, size_nopslide);
-	
-	if (nop_slide) { 			
-		HB_ReprotectMemory(nop_slide, 4, 7, &result);
-		for (i = 0; i < size_nopslide / sizeof(u32); i++) {
-			nop_slide[i] = ARM_NOP;
-		}
-		nop_slide[i-1] = ARM_RET;
-		nop_func = nop_slide;
-		HB_FlushInvalidateCache();
-	
-		nop_func();
-		free(nop_slide);
+	s32 i;
+	for(i = 0; i < 5; i++)
+	{
+		//Fills the top screen with random data
+		do_gshax_copy(0x14000000, 0x18000000, 0x46500);
+		svcSleepThread(0x400000LL);
+		do_gshax_copy(0x14046500, 0x18000000, 0x46500);
+		svcSleepThread(0x400000LL);
 	}
-	return;
 }
 
 /* get system dependent data and set up ARM11 structures */
@@ -443,7 +433,7 @@ s32 firm_reboot (void) {
 		fail_stage++; /* failure while trying to corrupt svcCreateThread() */
 		if (corrupt_svcCreateThread()) {
 			fail_stage++; /* Firmlaunch failure, ARM9 exploit failure*/
-			svcCorruptedCreateThread(priv_firm_reboot);
+				svcCorruptedCreateThread(priv_firm_reboot);
 		}
 	}
 

--- a/brahma/source/main.c
+++ b/brahma/source/main.c
@@ -9,49 +9,35 @@
 #include "sochlp.h"
 #include "payload_bin.h"
 
+
 s32 quick_boot_firm (s32 load_from_disk) {
 	if (load_from_disk)
 		load_arm9_payload_from_mem(payload_bin, payload_bin_size);
 	firm_reboot();	
 }
 
-s32 main(void) {
+s32 main (void) {
 	// Initialize services
-	srvInit();
-	aptInit();
-	hidInit(NULL);
 	gfxInitDefault();
 	gfxSet3D(true);
-	fsInit();
-	sdmcInit();
-	hbInit();
-	qtmInit();
 	gfxSwapBuffers();
 
 	Handle fileHandle;
 	u32 bytesRead;
 	FS_archive sdmcArchive = (FS_archive){ ARCH_SDMC, (FS_path){ PATH_EMPTY, 1, (u8*)"" } };
 	FS_path filePath = FS_makePath(PATH_CHAR, "/" CODE_PATH);
-	Result ret = FSUSER_OpenFileDirectly(NULL, &fileHandle, sdmcArchive, filePath, FS_OPEN_READ, FS_ATTRIBUTE_NONE);
+	Result ret = FSUSER_OpenFileDirectly(NULL, &fileHandle, sdmcArchive, filePath, FS_OPEN_READ, 		FS_ATTRIBUTE_NONE);
 	if (ret) goto EXIT;
 	FSFILE_Read(fileHandle, &bytesRead, 0x14000, 0x14400000, 320 * 1024);
 	FSFILE_Close(fileHandle);
 
-
-	if (brahma_init())
-	{
+	if (brahma_init()) {
 		quick_boot_firm(1);
 		brahma_exit();
 	}
 
 EXIT:
-	hbExit();
-	sdmcExit();
-	fsExit();
 	gfxExit();
-	hidExit();
-	aptExit();
-	srvExit();
 	// Return to hbmenu
 	return 0;
 }

--- a/brahma/source/menus.c
+++ b/brahma/source/menus.c
@@ -64,7 +64,7 @@ s32 print_main_menu (s32 idx, struct menu_t *menu) {
 	s32 newidx = 0;
 	consoleClear();
 
-	printf("\n* BRAHMA *\n\n\n");
+	printf("\n* BRAHMA II *\n\n\n");
 	printf("===========================\n");
 	newidx = print_menu(idx, menu);
 	printf("===========================\n\n");	


### PR DESCRIPTION
So in light of the port of brahma to *hax 2.0 based exploits by delebile (https://gbatemp.net/threads/porting-brahma-to-ninjhax2.398243/), I took the liberty of porting rxTools to this new code, and lo and behold, it boots successfully on my 9.2.0-20 EUR 3DS.

With this, we can now (with skillful payload running) autoboot rxTools using homemenuhax (and by proxy, other CFW solutions.)

This will need some tidying up though. And it only has an 80% boot rate so far. And it only works on O3DS. (Yes, it is quite obvious I'm jumping the gun here.)