### PR TITLE
Adjust section addresses for Process9

### DIFF
--- a/rxmode/agb_firm/Makefile
+++ b/rxmode/agb_firm/Makefile
@@ -27,9 +27,10 @@ endif
 
 include $(DEVKITARM)/base_rules
 
-TARGET 		:=  agb_firm
-SOURCE		:=	source
-LD		:=	arm-none-eabi-ld
+TARGET 	:= agb_firm
+SOURCE	:= source
+LD	:= arm-none-eabi-ld
+OBJCOPY	:= arm-none-eabi-objcopy
 
 .PHONY: clean all
 
@@ -38,10 +39,10 @@ all: $(BUILD)/$(TARGET).elf
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
 
-%.elf: %_unstrip.elf
-	$(STRIP) $< -o $@
+%.elf: %_unadjust.elf
+	$(OBJCOPY) -S --change-section-address .patch.p9.*+$$((0x08014A00 - 0x08020000)) $< $@
 
-$(BUILD)/$(TARGET)_unstrip.elf: $(BUILD)/p9_signatures_spoof.o
+$(BUILD)/$(TARGET)_unadjust.elf: $(BUILD)/p9_signatures_spoof.o
 	$(LD) -i -Tscript.ld $^ -o $@
 
 $(BUILD)/%.o: $(SOURCE)/%.s $(BUILD)

--- a/rxmode/native_firm/Makefile
+++ b/rxmode/native_firm/Makefile
@@ -30,6 +30,7 @@ include $(DEVKITARM)/base_rules
 TARGET	:= native_firm
 SOURCE	:= source
 LD	:= arm-none-eabi-ld
+OBJCOPY	:= arm-none-eabi-objcopy
 
 CFLAGS	:= -Os -fshort-wchar -fno-zero-initialized-in-bss $(INCDIR)
 
@@ -75,10 +76,10 @@ $(BUILD)/payload/arm9/myThread:
 $(BUILD)/payload/arm11:
 	@[ -d $@ ] || mkdir -p $@
 
-%.elf: %_unstrip.elf
-	$(STRIP) $< -o $@
+%.elf: %_unadjust.elf
+	$(OBJCOPY) -S --change-section-address .patch.p9.*+$$((0x0801CF00 - 0x08028000)) $< $@
 
-$(BUILD)/$(TARGET)_unstrip.elf: $(PATCHES)
+$(BUILD)/$(TARGET)_unadjust.elf: $(PATCHES)
 	$(LD) -i -T$(LDSCRIPT) $^ -o $@
 
 $(BUILD)/payload/payload.elf: $(PAYLOAD_OBJS) $(BUILD)/payload

--- a/rxmode/twl_firm/Makefile
+++ b/rxmode/twl_firm/Makefile
@@ -12,9 +12,10 @@ endif
 
 include $(DEVKITARM)/base_rules
 
-TARGET 		:=  twl_firm
-SOURCE		:=	source
-LD		:=	arm-none-eabi-ld
+TARGET	:= twl_firm
+SOURCE	:= source
+LD	:= arm-none-eabi-ld
+OBJCOPY	:= arm-none-eabi-objcopy
 
 .PHONY: clean all
 
@@ -23,10 +24,10 @@ all: $(BUILD)/$(TARGET).elf
 $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
 
-%.elf: %_unstrip.elf
-	$(STRIP) $< -o $@
+%.elf: %_unadjust.elf
+	$(OBJCOPY) -S --change-section-address .patch.p9.*+$$((0x08014A00 - 0x08020000)) $< $@
 
-$(BUILD)/$(TARGET)_unstrip.elf: $(BUILD)/p9_signatures_spoof.o
+$(BUILD)/$(TARGET)_unadjust.elf: $(BUILD)/p9_signatures_spoof.o
 	$(LD) -i -Tscript.ld $^ -o $@
 
 $(BUILD)/%.o: $(SOURCE)/%.s $(BUILD)

--- a/rxtools/source/features/configuration.c
+++ b/rxtools/source/features/configuration.c
@@ -236,8 +236,8 @@ int readCfg()
 }
 
 int InstallData(char* drive){
-	static const FirmInfo agb_info = { 0x8B800, 0x4CE00, 0x08006800, 0, 0, 0, 0xD600, 0xE200, 0x08020000};
-	static const FirmInfo twl_info = { 0x153600, 0x4D200, 0x08006800, 0, 0, 0, 0xD600, 0xE200, 0x08020000};
+	static const FirmInfo agb_info = { 0x8B800, 0x4CE00, 0x08006800, 0, 0, 0 };
+	static const FirmInfo twl_info = { 0x153600, 0x4D200, 0x08006800, 0, 0, 0 };
 	AppInfo appInfo;
 	FIL firmfile;
 	File fd;

--- a/rxtools/source/features/firm.c
+++ b/rxtools/source/features/firm.c
@@ -84,11 +84,8 @@ static int loadFirm(char *path, UINT *fsz)
 
 static unsigned int addrToOff(Elf32_Addr addr, const FirmInfo *info)
 {
-	if (addr >= info->arm9Entry && addr <= info->arm9Entry + info->p9Off)
+	if (addr >= info->arm9Entry && addr <= info->arm9Entry + info->arm9Size)
 		return info->arm9Off + (addr - info->arm9Entry);
-
-	if (addr >= info->p9Entry && addr <= info->p9Entry + info->arm9Size - info->p9Start)
-		return info->arm9Off + (addr - info->p9Entry) + info->p9Start;
 
 	if (addr >= info->arm11Entry && addr <= info->arm11Entry + info->arm11Size)
 		return info->arm11Off + (addr - info->arm11Entry);
@@ -182,8 +179,8 @@ int rxMode(int emu)
 		DrawBottomSplash(s);
 	}
 
-	static const FirmInfo ktrInfo = { 0x66A00, 0x8A600, 0x08006000, 0x33A00, 0x33000, 0x1FF80000, 0x15B00, 0x16700, 0x08028000 };
-	static const FirmInfo ctrInfo = { 0x66000, 0x84A00, 0x08006800, 0x35000, 0x31000, 0x1FF80000, 0x15B00, 0x16700, 0x08028000 };
+	static const FirmInfo ktrInfo = { 0x66A00, 0x8A600, 0x08006000, 0x33A00, 0x33000, 0x1FF80000 };
+	static const FirmInfo ctrInfo = { 0x66000, 0x84A00, 0x08006800, 0x35000, 0x31000, 0x1FF80000 };
 	static const char patchNandPrefix[] = ".patch.p9.nand";
 	unsigned int cur, off, shstrSize;
 	char path[64], shstrtab[512], *sh_name;

--- a/rxtools/source/features/firm.h
+++ b/rxtools/source/features/firm.h
@@ -29,9 +29,6 @@ typedef struct{
 	unsigned int arm11Off;
 	size_t arm11Size;
 	uintptr_t arm11Entry;
-	unsigned int p9Off;
-	uintptr_t p9Start;
-	uintptr_t p9Entry;
 } FirmInfo;
 
 typedef enum {


### PR DESCRIPTION
This conflicts with pull request #244, but I made this change because the offset of Process9 is not written in the header. Of course, it's possible to find it by looking for the magic, but I don't think it's a good solution.