### PR TITLE
Some tiny fixes

### DIFF
--- a/lang/zh-CN.json
+++ b/lang/zh-CN.json
@@ -83,5 +83,6 @@
     "NO": "否", 
     "MENU_LANGUAGE": "菜单语言  %12ls", 
     "SYSNAND": "真实系统", 
-    "EMUNAND": "虚拟系统"
+    "EMUNAND": "虚拟系统",
+    "RANDOM_THEME": "随机主题"
 }

--- a/rxtools/source/features/downgradeapp.c
+++ b/rxtools/source/features/downgradeapp.c
@@ -50,18 +50,17 @@ char tmpstr[256];
 FILINFO curInfo;
 DIR myDir;
 
-void sprint_sha256(wchar_t *str, unsigned char hash[32])
-{
-	int i;
-	for (i = 0; i < sizeof(hash); i++)
-	{
-		if ( (i & 0x10) == 0){
-			swprintf(str, 2, L"\n");
-			str++;
-		}
-		swprintf(str, 3, L"%02X", hash[i]);
-		str+=2;
-	}
+wchar_t sprint_sha256_char(char val) {
+    if (val < 10) return val + L'0';
+    else return val - 10 + L'A';
+}
+void sprint_sha256(wchar_t *str, unsigned char hash[32]) {
+    uint32_t i=0;
+    for (i=0;i<32;i++) {
+        if ((i)&&((i%8)==0)) {*str = L'\n'; str ++;}
+        *str = sprint_sha256_char(hash[i]>> 4); str ++;
+        *str = sprint_sha256_char(hash[i]&0xF); str ++;
+    }
 }
 
 

--- a/tools/cdn_firm.py
+++ b/tools/cdn_firm.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 import urllib
+import shutil
 
 firmdir = "firm"
 
@@ -11,6 +12,8 @@ def f(title, download):
 		firmdir + "/%016X.bin" % (title))
 
 print "Downloading 3DS firmware from the CDN..."
+if os.path.isdir(firmdir):
+	shutil.rmtree(firmdir)
 os.mkdir(firmdir)
 f(0x0004013800000002, 0x00000049)
 f(0x0004013800000202, 0x0000000B)


### PR DESCRIPTION
This commit does 3 things.
* Update of `zh-CN.json`. Absence of the needed string constant would cause it console messed up.
* Update of `sprint_sha256`. I accidentially found it. And new implementation fixed it, #277.
* Update of `cdn_firm.py`. So it would remove the `firm` folder when there is one already.

Cause none of above touches the main features of the CFW, i guess this is safe to be merged.
But, still hope any of you review it. *Have a good day.*