### PR TITLE
added "dbs/import.db" -> "Inject to Emunand"

### DIFF
--- a/rxtools/source/features/nandtools.c
+++ b/rxtools/source/features/nandtools.c
@@ -44,6 +44,7 @@ static struct {
     {"LocalFriendCodeSeed_B", "rw/sys"},
     {"rand_seed", "rw/sys"},
     {"ticket.db", "dbs"},
+    {"import.db", "dbs"},
 };
 
 static Menu CoolFilesMenu = {
@@ -54,6 +55,7 @@ static Menu CoolFilesMenu = {
 		{ L" LocalFriendCodeSeed_B", &SelectFile, "fil2.bin" },
 		{ L" rand_seed", &SelectFile, "fil3.bin" },
 		{ L" ticket.db", &SelectFile, "fil4.bin" },
+		{ L" import.db", &SelectFile, "fil5.bin" },
 	},
 	nCoolFiles,
 	0,


### PR DESCRIPTION
added "dbs/import.db" -> "Inject to Emunand" & "Dump to Emunand"
It's a fast and easy way to remove the update nag from emunand.
Like this POC:
https://gbatemp.net/threads/poc-removing-update-nag-on-emunand.399460/

please update theme pngs: file1.png-file5.png with "import.db"