### PR TITLE
Patch 2

### DIFF
--- a/tools/readme.txt
+++ b/tools/readme.txt
@@ -5,7 +5,7 @@ cdn_firm.exe :
     Once successfully generated, copy 'firm' to your rxTools directory.
 
 msetdg.exe :
-    Use this tool to downgrade your 'System Settings' app in sysNand.
+    Use this to downgrade your 'System Settings' app in sysNand.
     This is gives access to previous patched entrypoints but on firmware versions higher than 4.5.
     (such as various 'DS profile' exploits)    
     Once you've choosen your region, the 'msetdg.bin' file will be generated,

--- a/tools/readme.txt
+++ b/tools/readme.txt
@@ -1,14 +1,15 @@
 cdn_firm.exe :
-    Use this tool the first time you use rxTools.
-    It will generate 'firm' directory  (for New 3DS, you need to provide your own encrypted firm file!), containing files necessary for the toolkit to work.
-    Once it gets successfully generated, copy 'firm' to your rxTools directory.
+    Use this the first time you use rxTools.
+    It will generate 'firm' directory, containing files necessary for the toolkit to work.
+    (for N3DS, you need to provide your own encrypted 'firm' file!)
+    Once successfully generated, copy 'firm' to your rxTools directory.
 
 msetdg.exe :
-    Use this tool if you want to downgrade your System Settings app in your sysNand.
-    This is useful becouse will make that entrypoint available on systems versions
-    higher than 4.5.
-    Once you've choosen your region, the 'msetdg.bin' file will be generated, and you'll
-    have to copy it in the root of your sdcard.
+    Use this tool to downgrade your 'System Settings' app in sysNand.
+    This is gives access to previous patched entrypoints but on firmware versions higher than 4.5.
+    (such as various 'DS profile' exploits)    
+    Once you've choosen your region, the 'msetdg.bin' file will be generated,
+    copy this to the root of your sdcard.
     Once you downgraded the app, this file will automatically be deleted.
 
 (This file is originally written by Roxas75)


### PR DESCRIPTION
single spelling mistake becouse > because.

various rewrites due to 'ease of reading'/understand:

-changed to common terminology ("N3DS" instead of "new 3ds", to match commonly used o3ds/n3ds format)
-additional info on the purpose of Mset downgrading. (to avoid confusion amongst those who've never come across [Mset] before)