### PR TITLE
Fixed pad generating

### DIFF
--- a/rxtools/source/features/NandDumper.c
+++ b/rxtools/source/features/NandDumper.c
@@ -169,7 +169,7 @@ void DumpNandPartitions(){
 
 void GenerateNandXorpads(){
 
-	PadInfo myInfo = { .keyslot = getMpInfo() == MPINFO_KTR ? 0x5 : 0x4, .setKeyY = 0, .size_mb = getMpInfo() == MPINFO_KTR ? 1055 : 758, .filename = L"rxTools/nand.fat16.xorpad" };
+	PadInfo myInfo = { .keyslot = getMpInfo() == MPINFO_KTR ? 0x5 : 0x4, .setKeyY = 0, .size_mb = getMpInfo() == MPINFO_KTR ? 1055 : 758, .filename = "rxTools/nand.fat16.xorpad" };
 	GetNANDCTR(myInfo.CTR); add_ctr(myInfo.CTR, 0xB93000);
 
 	ConsoleInit();

--- a/rxtools/source/features/padgen.c
+++ b/rxtools/source/features/padgen.c
@@ -162,18 +162,20 @@ uint32_t CreatePad(PadInfo *info, int index)
 	#define BUFFER_ADDR ((volatile uint8_t*)0x21000000)
 	#define BLOCK_SIZE  (4*1024*1024)
 
-	if(info->filename[0] != 0 && info->filename[1] == 0 && info->filename[2] != 0 && info->filename[3] == 0)
+	wchar_t filename[sizeof(info->filename)];
+	mbstowcs(filename, info->filename, sizeof(info->filename));
+	if(filename[0] != 0 && filename[1] == 0 && filename[2] != 0 && filename[3] == 0)
 	{
-		wchar_t fname[sizeof(info->filename) / 2];
-		for(int i = 0; i < sizeof(info->filename) / 2; ++i)
+		wchar_t fname[sizeof(filename) / 2];
+		for(int i = 0; i < sizeof(filename) / 2; ++i)
 		{
-			fname[i] = info->filename[i*2];
+			fname[i] = filename[i*2];
 			if(fname[i] == 0) break;
 		}
 		if (!FileOpen(&pf, wcsncmp(fname, L"sdmc:/", 6) == 0 ? fname + 6 : fname, 1))
 			return 1;
 	}
-	else if (!FileOpen(&pf, info->filename, 1))
+	else if (!FileOpen(&pf, filename, 1))
 		return 1;
 
 	if(info->setKeyY != 0)

--- a/rxtools/source/features/padgen.h
+++ b/rxtools/source/features/padgen.h
@@ -23,7 +23,7 @@
 typedef struct {
     uint8_t   CTR[16];
     uint32_t  size_mb;
-    TCHAR filename[180];
+    char filename[180];
 } __attribute__((packed)) SdInfoEntry;
 
 typedef struct {
@@ -38,7 +38,7 @@ typedef struct {
     uint32_t  size_mb;
     uint8_t   reserved[8];
     uint32_t  uses7xCrypto;
-    TCHAR filename[112];
+    char filename[112];
 } __attribute__((packed)) NcchInfoEntry;
 
 typedef struct {
@@ -56,7 +56,7 @@ typedef struct {
     uint8_t   CTR[16];
     uint8_t   keyY[16];
     uint32_t  size_mb;
-    TCHAR filename[180];
+    char filename[180];
 } __attribute__((packed, aligned(16))) PadInfo;
 
 uint32_t CreatePad(PadInfo *info, int index);


### PR DESCRIPTION
Fixed #347 
Reverted the type of `filename` field of structs in padgen.h to `char` so that there's no need to change the bin file's format.