### PR TITLE
Add a lot of TWL_FIRM patches, see https://gist.github.com/Steveice10/8a6965c59192ac970832

### DIFF
--- a/rxmode/twl_firm/Makefile
+++ b/rxmode/twl_firm/Makefile
@@ -39,7 +39,7 @@ $(BUILD):
 %_unstrip.elf: %_linked.elf
 	$(call Q,LINK,$@)$(LD) -i -Tscript.ld $< -o $@
 
-$(BUILD)/$(TARGET)_linked.elf: $(BUILD)/p9_signatures_spoof.o
+$(BUILD)/$(TARGET)_linked.elf: $(BUILD)/p9_signatures_spoof.o $(BUILD)/p9_sha_compare_stub.o $(BUILD)/p9_whitelist_check_disable.o $(BUILD)/p9_cartridge_save_type_check_disable.o $(BUILD)/p9_dsi_cartridge_save_exploit_check_disable.o $(BUILD)/p9_ninlogo_check_disable.o $(BUILD)/p9_blacklist_check_disable.o
 	$(call Q,LINK,$@)$(LD) -Tscript.ld $^ -o $@
 
 $(BUILD)/%.o: $(SOURCE)/%.s $(BUILD)

--- a/rxmode/twl_firm/script.ld
+++ b/rxmode/twl_firm/script.ld
@@ -1,5 +1,25 @@
+twl_p9 = 0x8014A00;
+
 SECTIONS
 {
-	. = 0x080182C0;
+	. = twl_p9 + 0x38C0;
 	.patch.p9.sig : { *(.patch.p9.sig) }
+	
+	. = twl_p9 + 0x13656;
+	.patch.p9.sha_compare_stub : { *(.patch.p9.sha_compare_stub) }
+	
+	. = twl_p9 + 0x13164;
+	.patch.p9.whitelist_check_disable : { *(.patch.p9.whitelist_check_disable) }
+	
+	. = twl_p9 + 0x1355E;
+	.patch.p9.cartridge_save_type_check_disable : { *(.patch.p9.cartridge_save_type_check_disable) }
+	
+	. = twl_p9 + 0x1356A;
+	.patch.p9.dsi_cartridge_save_exploit_check_disable : { *(.patch.p9.dsi_cartridge_save_exploit_check_disable) }
+	
+	. = twl_p9 + 0x13002;
+	.patch.p9.ninlogo_check_disable : { *(.patch.p9.ninlogo_check_disable) }
+	
+	. = twl_p9 + 0x13552;
+	.patch.p9.blacklist_check_disable : { *(.patch.p9.blacklist_check_disable) }
 }

--- a/rxmode/twl_firm/source/p9_blacklist_check_disable.s
+++ b/rxmode/twl_firm/source/p9_blacklist_check_disable.s
@@ -1,0 +1,8 @@
+@ Blacklist check patch found by TuxSH (see https://gist.github.com/Steveice10/8a6965c59192ac970832).
+@ Disables the cartridge blacklist check (mostly, if not entirely, demo carts). This check was introduced in firmware 4.4.0-10.
+
+.section .patch.p9.blacklist_check_disable, "a"
+.thumb
+	mov		r0, #1
+	nop
+.pool

--- a/rxmode/twl_firm/source/p9_cartridge_save_type_check_disable.s
+++ b/rxmode/twl_firm/source/p9_cartridge_save_type_check_disable.s
@@ -1,0 +1,8 @@
+@ Cartridge save type check patch found by TuxSH (see https://gist.github.com/Steveice10/8a6965c59192ac970832).
+@ This check was introduced firmware 4.4.0-10, and blocked most DSi-compatible flashcarts as a result.
+
+.section .patch.p9.cartridge_save_type_check_disable, "a"
+.thumb
+	mov		r0, #1
+	nop
+.pool

--- a/rxmode/twl_firm/source/p9_dsi_cartridge_save_exploit_check_disable.s
+++ b/rxmode/twl_firm/source/p9_dsi_cartridge_save_exploit_check_disable.s
@@ -1,5 +1,5 @@
 @ DSi cartridge save file exploit check patch found by Steveice10 (see https://gist.github.com/Steveice10/8a6965c59192ac970832).
-@ This check was blocking, for instance, the "Cooking Mama" and "The Biggest Loser" DSi-mode exploits. 
+@ This check was blocking, for instance, the "Classic Word Games" and "Cooking Coach" DSi-mode exploits. 
 
 .section .patch.p9.dsi_cartridge_save_exploit_check_disable, "a"
 .thumb

--- a/rxmode/twl_firm/source/p9_dsi_cartridge_save_exploit_check_disable.s
+++ b/rxmode/twl_firm/source/p9_dsi_cartridge_save_exploit_check_disable.s
@@ -1,0 +1,8 @@
+@ DSi cartridge save file exploit check patch found by Steveice10 (see https://gist.github.com/Steveice10/8a6965c59192ac970832).
+@ This check was blocking, for instance, the "Cooking Mama" and "The Biggest Loser" DSi-mode exploits. 
+
+.section .patch.p9.dsi_cartridge_save_exploit_check_disable, "a"
+.thumb
+	mov		r0, #1
+	nop
+.pool

--- a/rxmode/twl_firm/source/p9_ninlogo_check_disable.s
+++ b/rxmode/twl_firm/source/p9_ninlogo_check_disable.s
@@ -1,0 +1,8 @@
+@ Nintendo logo check patch found by Steveice10 (see https://gist.github.com/Steveice10/8a6965c59192ac970832)
+@ It isn't generally needed
+
+.section .patch.p9.ninlogo_check_disable, "a"
+.thumb
+	mov		r0, #0
+	nop
+.pool

--- a/rxmode/twl_firm/source/p9_sha_compare_stub.s
+++ b/rxmode/twl_firm/source/p9_sha_compare_stub.s
@@ -1,0 +1,8 @@
+@ Signature/hash patch found by Steveice10, see https://gist.github.com/Steveice10/8a6965c59192ac970832
+@ This stubs the function commonly used to compare SHA hashes to always succeed. It's at least used to check SRL (DSi titles) signatures and SHA hashes in general.
+
+.section .patch.p9.sha_compare_stub, "a"
+.thumb
+	mov		r0, #1
+	bx		lr
+.pool

--- a/rxmode/twl_firm/source/p9_whitelist_check_disable.s
+++ b/rxmode/twl_firm/source/p9_whitelist_check_disable.s
@@ -1,0 +1,7 @@
+@ Whitelist check patch found by Steveice10, see https://gist.github.com/Steveice10/8a6965c59192ac970832
+
+.section .patch.p9.whitelist_check_disable, "a"
+.thumb
+	mov		r0, #0
+	nop
+.pool


### PR DESCRIPTION
This pull request add the following patches to TWL_FIRM (v8817, still only for O3DS right now, but could easly be ported to N3DS, I believe):
1. A SHA compare stub, in other words, a signature patch and a hash patch, allowing unsigned and/or corrupt DS(i) titles to run. **In other words: region-free DSiWare and DSiWare romhacks are now possible**
2. A whitelist check patch, enabling whitelisted DSi flashcarts to run without any update
3. A save type check patch, enabling flashcarts that were previously blocked by firmware 4.4.0-10 to run without any update. **With this patch and the one above, you should be able to run most DSi-compatible flashcarts**
4. A DSi cartridge save exploit check patch, for "Classic Word Games" and "Cooking Coach"
5. A blacklist check patch, mainly (if not exclusively) to run demo cartridges
6. A Nintendo logo check patch, even if it's not really needed

Patches 1., 2., 4., 6., were found by @Steveice10 while patches 3. and 5. were found by me.
A huge thanks to @ApacheThunder as well for the amazing work he did on the issue (unpacking, packing patched TWL_FIRM, testing as well as many other things).

For some reasons there is still something to patch to get titles like TWLNandFiler to work.
It's possible that DSiWare banners aren't displayed correctly.
