### PR TITLE
Adding p9_rsa_validity_check_disable.s (TWL_FIRM patch)

### DIFF
--- a/rxmode/twl_firm/Makefile
+++ b/rxmode/twl_firm/Makefile
@@ -39,7 +39,7 @@ $(BUILD):
 %_unstrip.elf: %_linked.elf
 	$(call Q,LINK,$@)$(LD) -i -Tscript.ld $< -o $@
 
-$(BUILD)/$(TARGET)_linked.elf: $(BUILD)/p9_signatures_spoof.o $(BUILD)/p9_sha_compare_stub.o $(BUILD)/p9_whitelist_check_disable.o $(BUILD)/p9_cartridge_save_type_check_disable.o $(BUILD)/p9_dsi_cartridge_save_exploit_check_disable.o $(BUILD)/p9_ninlogo_check_disable.o $(BUILD)/p9_blacklist_check_disable.o
+$(BUILD)/$(TARGET)_linked.elf: $(BUILD)/p9_signatures_spoof.o $(BUILD)/p9_sha_compare_stub.o $(BUILD)/p9_rsa_validity_check_disable.o $(BUILD)/p9_whitelist_check_disable.o $(BUILD)/p9_cartridge_save_type_check_disable.o $(BUILD)/p9_dsi_cartridge_save_exploit_check_disable.o $(BUILD)/p9_ninlogo_check_disable.o $(BUILD)/p9_blacklist_check_disable.o
 	$(call Q,LINK,$@)$(LD) -Tscript.ld $^ -o $@
 
 $(BUILD)/%.o: $(SOURCE)/%.s $(BUILD)

--- a/rxmode/twl_firm/script.ld
+++ b/rxmode/twl_firm/script.ld
@@ -8,6 +8,9 @@ SECTIONS
 	. = twl_p9 + 0x13656;
 	.patch.p9.sha_compare_stub : { *(.patch.p9.sha_compare_stub) }
 	
+	. = twl_p9 + 0x1220e;
+	.patch.p9.rsa_validity_check_disable : { *(.patch.p9.rsa_validity_check_disable) }
+	
 	. = twl_p9 + 0x13164;
 	.patch.p9.whitelist_check_disable : { *(.patch.p9.whitelist_check_disable) }
 	

--- a/rxmode/twl_firm/source/p9_rsa_validity_check_disable.s
+++ b/rxmode/twl_firm/source/p9_rsa_validity_check_disable.s
@@ -1,0 +1,7 @@
+@ Found by Steveice10 (O3DS) / AuroraWright (N3DS)
+@ See https://gbatemp.net/threads/ds-i-mode-hacking-progress-thread.413015/page-39#post-6077734 for further details
+
+.section .patch.p9.rsa_validity_check_disable, "a"
+.thumb
+	mov		r0, #1
+.pool


### PR DESCRIPTION
[Patch](https://gist.github.com/Steveice10/8a6965c59192ac970832) courtesy of @Steveice10.
See [here](https://gbatemp.net/threads/ds-i-mode-hacking-progress-thread.413015/page-39#post-6077734) for further details.